### PR TITLE
Add nullable support

### DIFF
--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
@@ -74,10 +74,19 @@ public class CodeGenerator implements Application {
         BalController listenerController = new ListenerController(serviceTypes);
         String listenerBalContent = listenerController.generateBalCode(listenerTemplate);
 
-        String dispatcherTemplate = fileRepository
-                .getFileContentFromResources(Constants.DISPATCHER_SERVICE_BAL_FILE_NAME);
         BalController dispatcherController = new DispatcherController(serviceTypes, eventIdentifierPath);
-        String dispatcherContent = dispatcherController.generateBalCode(dispatcherTemplate);
+        String dispatcherContent = "";
+        if (isEventIdentifierInBody(eventIdentifierPath)) {
+            String dispatcherTemplateForEventIdentifierInBody = fileRepository
+                    .getFileContentFromResources(
+                            Constants.DISPATCHER_SERVICE_BAL_FILE_NAME_FOR_EVENT_IDENTIFIER_IN_BODY);
+            dispatcherContent = dispatcherController.generateBalCode(dispatcherTemplateForEventIdentifierInBody);
+        } else {
+            String dispatcherTemplateForEventIdentifierInHeader = fileRepository
+                    .getFileContentFromResources(
+                            Constants.DISPATCHER_SERVICE_BAL_FILE_NAME_FOR_EVENT_IDENTIFIER_IN_HEADER);
+            dispatcherContent = dispatcherController.generateBalCode(dispatcherTemplateForEventIdentifierInHeader);
+        }
 
         String outputDirectory = getOutputDirectory(outputPath);
         fileRepository.writeToFile(outputDirectory.concat(Constants.DATA_TYPES_BAL_FILE_NAME), dataTypesBalContent);
@@ -108,5 +117,12 @@ public class CodeGenerator implements Application {
         } else {
             throw new BallerinaAsyncApiException("Unknown file type: ".concat(specPath));
         }
+    }
+
+    private Boolean isEventIdentifierInBody(String eventIdentifierPath) {
+        if (eventIdentifierPath.startsWith(Constants.CLONE_WITH_TYPE_VAR_NAME)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
@@ -61,6 +61,7 @@ public class CodeGenerator implements Application {
         SpecController specController = new AsyncApiSpecController(asyncApiSpecJson);
         Map<String, Schema> schemas = specController.getSchemas();
         List<ServiceType> serviceTypes = specController.getServiceTypes();
+        String eventIdentifierType = specController.getEventIdentifierType();
         String eventIdentifierPath = specController.getEventIdentifierPath();
 
         String dataTypesTemplate = fileRepository.getFileContentFromResources(Constants.DATA_TYPES_BAL_FILE_NAME);
@@ -74,9 +75,10 @@ public class CodeGenerator implements Application {
         BalController listenerController = new ListenerController(serviceTypes);
         String listenerBalContent = listenerController.generateBalCode(listenerTemplate);
 
-        BalController dispatcherController = new DispatcherController(serviceTypes, eventIdentifierPath);
+        BalController dispatcherController = new DispatcherController(serviceTypes, eventIdentifierType,
+                eventIdentifierPath);
         String dispatcherContent = "";
-        if (isEventIdentifierInBody(eventIdentifierPath)) {
+        if (eventIdentifierType.equals(Constants.X_BALLERINA_EVENT_TYPE_BODY)) {
             String dispatcherTemplateForEventIdentifierInBody = fileRepository
                     .getFileContentFromResources(
                             Constants.DISPATCHER_SERVICE_BAL_FILE_NAME_FOR_EVENT_IDENTIFIER_IN_BODY);
@@ -117,12 +119,5 @@ public class CodeGenerator implements Application {
         } else {
             throw new BallerinaAsyncApiException("Unknown file type: ".concat(specPath));
         }
-    }
-
-    private Boolean isEventIdentifierInBody(String eventIdentifierPath) {
-        if (eventIdentifierPath.startsWith(Constants.CLONE_WITH_TYPE_VAR_NAME)) {
-            return true;
-        }
-        return false;
     }
 }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/configuration/Constants.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/configuration/Constants.java
@@ -29,6 +29,10 @@ public final class Constants {
     public static final String LISTENER_BAL_FILE_NAME = "listener.bal";
     public static final String SERVICE_TYPES_BAL_FILE_NAME = "service_types.bal";
     public static final String DISPATCHER_SERVICE_BAL_FILE_NAME = "dispatcher_service.bal";
+    public static final String DISPATCHER_SERVICE_BAL_FILE_NAME_FOR_EVENT_IDENTIFIER_IN_BODY =
+            "dispatcher_service.bal";
+    public static final String DISPATCHER_SERVICE_BAL_FILE_NAME_FOR_EVENT_IDENTIFIER_IN_HEADER =
+            "dispatcher_service_for_event_identifier_in_header.bal";
     public static final List<String> BAL_KEYWORDS;
     public static final List<String> BAL_TYPES;
     public static final String ESCAPE_PATTERN = "([\\[\\]\\\\?!<>@#&~`*\\-=^+();:\\/\\_{}\\s|.$])";
@@ -71,11 +75,12 @@ public final class Constants {
     public static final String X_BALLERINA_EVENT_TYPE_HEADER = "header";
     public static final String X_BALLERINA_EVENT_TYPE_BODY = "body";
     public static final String X_BALLERINA_EVENT_FIELD_IDENTIFIER_PATH = "path";
-
+    public static final String X_BALLERINA_EVENT_FIELD_IDENTIFIER_NAME = "name";
     public static final String CLONE_WITH_TYPE_VAR_NAME = "genericDataType";
     public static final String INTEROP_INVOKE_FUNCTION_NAME = "executeRemoteFunc";
     public static final String LISTENER_SERVICE_TYPE_FILTER_FUNCTION_NAME = "getServiceTypeStr";
     public static final String DISPATCHER_SERVICE_RESOURCE_FILTER_FUNCTION_NAME = "matchRemoteFunc";
+    public static final String DISPATCHER_SERVICE_POST_FUNCTION_NAME = "post";
     public static final String REMOTE_FUNCTION_NAME_PREFIX = "on";
     public static final String SERVICE_TYPE_NAME_SUFFIX = "Service";
 

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/AsyncApiSpecController.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/AsyncApiSpecController.java
@@ -29,6 +29,7 @@ import io.ballerina.asyncapi.codegenerator.entity.Schema;
 import io.ballerina.asyncapi.codegenerator.entity.ServiceType;
 import io.ballerina.asyncapi.codegenerator.usecase.ExtractChannelsFromSpec;
 import io.ballerina.asyncapi.codegenerator.usecase.ExtractIdentifierPathFromSpec;
+import io.ballerina.asyncapi.codegenerator.usecase.ExtractIdentifierTypeFromSpec;
 import io.ballerina.asyncapi.codegenerator.usecase.ExtractSchemasFromSpec;
 import io.ballerina.asyncapi.codegenerator.usecase.Extractor;
 
@@ -42,6 +43,7 @@ import java.util.Set;
 public class AsyncApiSpecController implements SpecController {
     private List<ServiceType> serviceTypes;
     private Map<String, Schema> schemas;
+    private String eventIdentifierType;
     private String eventIdentifierPath;
 
     public AsyncApiSpecController(String asyncApiSpecJson) throws BallerinaAsyncApiException {
@@ -60,12 +62,14 @@ public class AsyncApiSpecController implements SpecController {
 
         Extractor extractServiceTypes = new ExtractChannelsFromSpec(asyncApiSpec);
         Extractor extractSchemas = new ExtractSchemasFromSpec(asyncApiSpec);
+        Extractor extractIdentifierType = new ExtractIdentifierTypeFromSpec(asyncApiSpec);
         Extractor extractIdentifierPath = new ExtractIdentifierPathFromSpec(asyncApiSpec);
 
         MultiChannel multiChannel = extractServiceTypes.extract();
         serviceTypes = multiChannel.getServiceTypes();
         schemas = extractSchemas.extract();
         schemas.putAll(multiChannel.getInlineSchemas());
+        eventIdentifierType = extractIdentifierType.extract();
         eventIdentifierPath = extractIdentifierPath.extract();
     }
 
@@ -77,6 +81,11 @@ public class AsyncApiSpecController implements SpecController {
     @Override
     public Map<String, Schema> getSchemas() {
         return schemas;
+    }
+
+    @Override
+    public String getEventIdentifierType() {
+        return eventIdentifierType;
     }
 
     @Override

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherController.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherController.java
@@ -75,10 +75,13 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
  */
 public class DispatcherController implements BalController {
     private final List<ServiceType> serviceTypes;
+    private final String eventIdentifierType;
     private final String eventIdentifierPath;
 
-    public DispatcherController(List<ServiceType> serviceTypes, String eventIdentifierPath) {
+    public DispatcherController(List<ServiceType> serviceTypes, String eventIdentifierType,
+                                String eventIdentifierPath) {
         this.serviceTypes = serviceTypes;
+        this.eventIdentifierType = eventIdentifierType;
         this.eventIdentifierPath = eventIdentifierPath;
     }
 
@@ -88,8 +91,8 @@ public class DispatcherController implements BalController {
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         ModulePartNode oldRoot = syntaxTree.rootNode();
 
-        String eventIdentifierPath = this.eventIdentifierPath;
-        if (isEventIdentifierInHeader(this.eventIdentifierPath)) {
+        String eventIdentifierPath = Constants.CLONE_WITH_TYPE_VAR_NAME.concat(".").concat(this.eventIdentifierPath);
+        if (this.eventIdentifierType.equals(Constants.X_BALLERINA_EVENT_TYPE_HEADER)) {
             eventIdentifierPath = "eventIdentifier";
 
             FunctionDefinitionNode postFunctionDefinitionNode = getPostFuncNode(oldRoot);
@@ -195,13 +198,6 @@ public class DispatcherController implements BalController {
                 createVariableDeclarationNode(createEmptyNodeList(), null, typedBindingPatternNode,
                         createToken(EQUAL_TOKEN), initializer, createToken(SEMICOLON_TOKEN));
         return eventIdentifierNode;
-    }
-
-    private Boolean isEventIdentifierInHeader(String eventIdentifierPath) {
-        if (eventIdentifierPath.startsWith(Constants.CLONE_WITH_TYPE_VAR_NAME)) {
-            return false;
-        }
-        return true;
     }
 }
 

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherController.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherController.java
@@ -23,23 +23,52 @@ import io.ballerina.asyncapi.codegenerator.configuration.Constants;
 import io.ballerina.asyncapi.codegenerator.entity.ServiceType;
 import io.ballerina.asyncapi.codegenerator.usecase.GenerateMatchStatementNode;
 import io.ballerina.asyncapi.codegenerator.usecase.Generator;
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
 import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 
 import java.util.List;
+
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createToken;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createBuiltinSimpleNameReferenceNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createCaptureBindingPatternNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createCheckExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createIdentifierToken;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createMethodCallExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createPositionalArgumentNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createSeparatedNodeList;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createTypedBindingPatternNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createVariableDeclarationNode;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.CHECK_KEYWORD;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.CLOSE_PAREN_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.DOT_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.EQUAL_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_PAREN_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.STRING_KEYWORD;
 
 /**
  * This file contains the logics and functions related to code generation of the dispatcher_service.bal.
@@ -58,8 +87,31 @@ public class DispatcherController implements BalController {
         TextDocument textDocument = TextDocuments.from(balTemplate);
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         ModulePartNode oldRoot = syntaxTree.rootNode();
-        FunctionDefinitionNode functionDefinitionNode = getResourceFuncNode(oldRoot);
 
+        String eventIdentifierPath = this.eventIdentifierPath;
+        if (isEventIdentifierInHeader(this.eventIdentifierPath)) {
+            eventIdentifierPath = "eventIdentifier";
+
+            FunctionDefinitionNode postFunctionDefinitionNode = getPostFuncNode(oldRoot);
+            if (postFunctionDefinitionNode == null) {
+                throw new BallerinaAsyncApiException("Resource function '"
+                        + Constants.DISPATCHER_SERVICE_POST_FUNCTION_NAME
+                        + "', is not found in the dispatcher_service.bal");
+            }
+
+            FunctionBodyBlockNode postFunctionBodyBlockNode =
+                    (FunctionBodyBlockNode) postFunctionDefinitionNode.functionBody();
+            NodeList<StatementNode> oldStatement = postFunctionBodyBlockNode.statements();
+            oldStatement = oldStatement.remove(1);
+            NodeList<StatementNode> newStatement = oldStatement.add(1, getEventIdentifierNode());
+            FunctionBodyBlockNode postFunctionBodyBlockNodeNew =
+                    postFunctionBodyBlockNode.modify().withStatements(newStatement).apply();
+            ModulePartNode midRoot  = oldRoot.replace(postFunctionBodyBlockNode, postFunctionBodyBlockNodeNew);
+            syntaxTree = syntaxTree.replaceNode(oldRoot, midRoot);
+            oldRoot = syntaxTree.rootNode();
+        }
+
+        FunctionDefinitionNode functionDefinitionNode = getResourceFuncNode(oldRoot);
         if (functionDefinitionNode == null) {
             throw new BallerinaAsyncApiException("Resource function '"
                     + Constants.DISPATCHER_SERVICE_RESOURCE_FILTER_FUNCTION_NAME
@@ -68,6 +120,7 @@ public class DispatcherController implements BalController {
 
         Generator generateMatchStatement = new GenerateMatchStatementNode(serviceTypes, eventIdentifierPath);
         MatchStatementNode matchStatementNode = generateMatchStatement.generate();
+
         FunctionBodyBlockNode functionBodyBlockNode = (FunctionBodyBlockNode) functionDefinitionNode.functionBody();
         NodeList<StatementNode> oldStatements = functionBodyBlockNode.statements();
         NodeList<StatementNode> newStatements =
@@ -98,6 +151,57 @@ public class DispatcherController implements BalController {
             }
         }
         return null;
+    }
+
+    private FunctionDefinitionNode getPostFuncNode(ModulePartNode oldRoot) {
+        for (ModuleMemberDeclarationNode node : oldRoot.members()) {
+            if (node.kind() == SyntaxKind.CLASS_DEFINITION) {
+                for (Node funcNode : ((ClassDefinitionNode) node).members()) {
+                    if ((funcNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION)
+                            && ((FunctionDefinitionNode) funcNode).functionName().text().equals(
+                            Constants.DISPATCHER_SERVICE_POST_FUNCTION_NAME)) {
+                        return (FunctionDefinitionNode) funcNode;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private VariableDeclarationNode getEventIdentifierNode() {
+        // {@code string eventIdentifier}
+        BuiltinSimpleNameReferenceNode typeBindingPattern = createBuiltinSimpleNameReferenceNode(null,
+                createToken(STRING_KEYWORD));
+        CaptureBindingPatternNode bindingPattern = createCaptureBindingPatternNode(
+                createIdentifierToken("eventIdentifier"));
+        TypedBindingPatternNode typedBindingPatternNode = createTypedBindingPatternNode(typeBindingPattern,
+                bindingPattern);
+
+        // {@code check request.getHeader("event-name")}
+        SimpleNameReferenceNode variableName = createSimpleNameReferenceNode(createIdentifierToken("request"));
+        SimpleNameReferenceNode methodName = createSimpleNameReferenceNode(createIdentifierToken("getHeader"));
+        SimpleNameReferenceNode argumentName =
+                createSimpleNameReferenceNode(createIdentifierToken("\"" + this.eventIdentifierPath + "\""));
+        FunctionArgumentNode eventIdentifierArgument = createPositionalArgumentNode(argumentName);
+        SeparatedNodeList<FunctionArgumentNode> arguments = createSeparatedNodeList(eventIdentifierArgument);
+        MethodCallExpressionNode methodCallExpression =
+                createMethodCallExpressionNode(variableName, createToken(DOT_TOKEN), methodName,
+                        createToken(OPEN_PAREN_TOKEN), arguments, createToken(CLOSE_PAREN_TOKEN));
+        CheckExpressionNode initializer =
+                createCheckExpressionNode(null, createToken(CHECK_KEYWORD), methodCallExpression);
+
+        // {@code string eventIdentifier = check request.getHeader("event-name");}
+        VariableDeclarationNode eventIdentifierNode =
+                createVariableDeclarationNode(createEmptyNodeList(), null, typedBindingPatternNode,
+                        createToken(EQUAL_TOKEN), initializer, createToken(SEMICOLON_TOKEN));
+        return eventIdentifierNode;
+    }
+
+    private Boolean isEventIdentifierInHeader(String eventIdentifierPath) {
+        if (eventIdentifierPath.startsWith(Constants.CLONE_WITH_TYPE_VAR_NAME)) {
+            return false;
+        }
+        return true;
     }
 }
 

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/SpecController.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/controller/SpecController.java
@@ -30,5 +30,6 @@ import java.util.Map;
 public interface SpecController {
     List<ServiceType> getServiceTypes();
     Map<String, Schema> getSchemas();
+    String getEventIdentifierType();
     String getEventIdentifierPath();
 }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpec.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpec.java
@@ -37,19 +37,9 @@ public class ExtractIdentifierPathFromSpec implements Extractor {
 
     @Override
     public String extract() throws BallerinaAsyncApiException {
-        if (asyncApiSpec.getExtension(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER) == null) {
-            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER
-                    .concat(" attribute is not found in the Async API Specification"));
-        }
         Extension identifier = asyncApiSpec.getExtension(
                 Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER);
         HashMap<String, String> valuesMap = (HashMap<String, String>) identifier.value;
-        if (!valuesMap.containsKey(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)) {
-            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE
-                    .concat(" attribute is not found within the attribute "
-                            .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
-                            .concat(" in the Async API Specification")));
-        }
         StringBuilder eventPathString = new StringBuilder("");
         if (valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
                 .equals(Constants.X_BALLERINA_EVENT_TYPE_HEADER)) {
@@ -76,11 +66,12 @@ public class ExtractIdentifierPathFromSpec implements Extractor {
                                 .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
                                 .concat(" in the Async API Specification")));
             }
-            eventPathString.append(Constants.CLONE_WITH_TYPE_VAR_NAME);
             String identifierPath = valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_PATH);
             String[] pathParts = identifierPath.split("\\.");
+            String prefix = "";
             for (String eventPathPart : pathParts) {
-                eventPathString.append(".");
+                eventPathString.append(prefix);
+                prefix = ".";
                 if (Constants.BAL_KEYWORDS.stream()
                         .anyMatch(eventPathPart::equals)) {
                     eventPathString.append("'").append(eventPathPart);
@@ -88,14 +79,6 @@ public class ExtractIdentifierPathFromSpec implements Extractor {
                     eventPathString.append(eventPathPart);
                 }
             }
-        } else {
-            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_TYPE_HEADER.concat(" or ")
-                    .concat(Constants.X_BALLERINA_EVENT_TYPE_BODY)
-                    .concat(" is not provided as the value of ")
-                    .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
-                    .concat(" attribute within the attribute "
-                            .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
-                            .concat(" in the Async API Specification")));
         }
         return eventPathString.toString();
     }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpec.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpec.java
@@ -50,17 +50,33 @@ public class ExtractIdentifierPathFromSpec implements Extractor {
                             .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
                             .concat(" in the Async API Specification")));
         }
-        StringBuilder eventPathString = new StringBuilder(Constants.CLONE_WITH_TYPE_VAR_NAME);
+        StringBuilder eventPathString = new StringBuilder("");
         if (valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
                 .equals(Constants.X_BALLERINA_EVENT_TYPE_HEADER)) {
-            //TODO: Handle header event path
-        } else { // Defaults to BODY
+            // Handle header event path
+            if (!valuesMap.containsKey(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_NAME)) {
+                throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_NAME
+                        .concat(" attribute is not found within the attribute "
+                                .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
+                                .concat(" in the Async API Specification")));
+            }
+            String identifierName = valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_NAME);
+            if (Constants.BAL_KEYWORDS.stream()
+                    .anyMatch(identifierName::equals)) {
+                eventPathString.append("'").append(identifierName);
+            } else {
+                eventPathString.append(identifierName);
+            }
+        } else if (valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
+                .equals(Constants.X_BALLERINA_EVENT_TYPE_BODY)) {
+            // Handle body event path
             if (!valuesMap.containsKey(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_PATH)) {
                 throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_PATH
                         .concat(" attribute is not found within the attribute "
                                 .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
                                 .concat(" in the Async API Specification")));
             }
+            eventPathString.append(Constants.CLONE_WITH_TYPE_VAR_NAME);
             String identifierPath = valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_PATH);
             String[] pathParts = identifierPath.split("\\.");
             for (String eventPathPart : pathParts) {
@@ -72,6 +88,14 @@ public class ExtractIdentifierPathFromSpec implements Extractor {
                     eventPathString.append(eventPathPart);
                 }
             }
+        } else {
+            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_TYPE_HEADER.concat(" or ")
+                    .concat(Constants.X_BALLERINA_EVENT_TYPE_BODY)
+                    .concat(" is not provided as the value of ")
+                    .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
+                    .concat(" attribute within the attribute "
+                            .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
+                            .concat(" in the Async API Specification")));
         }
         return eventPathString.toString();
     }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierTypeFromSpec.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierTypeFromSpec.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.usecase;
+
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.core.models.Extension;
+import io.ballerina.asyncapi.codegenerator.configuration.BallerinaAsyncApiException;
+import io.ballerina.asyncapi.codegenerator.configuration.Constants;
+
+import java.util.HashMap;
+
+/**
+ * Extract the identifier type from the AsyncAPI specification.
+ */
+public class ExtractIdentifierTypeFromSpec implements Extractor {
+    private final AaiDocument asyncApiSpec;
+
+    public ExtractIdentifierTypeFromSpec(AaiDocument asyncApiSpec) {
+        this.asyncApiSpec = asyncApiSpec;
+    }
+
+    @Override
+    public String extract() throws BallerinaAsyncApiException {
+        if (asyncApiSpec.getExtension(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER) == null) {
+            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER
+                    .concat(" attribute is not found in the Async API Specification"));
+        }
+        Extension identifier = asyncApiSpec.getExtension(
+                Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER);
+        HashMap<String, String> valuesMap = (HashMap<String, String>) identifier.value;
+        if (!valuesMap.containsKey(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)) {
+            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE
+                    .concat(" attribute is not found within the attribute "
+                            .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
+                            .concat(" in the Async API Specification")));
+        }
+        StringBuilder eventIdentifierType = new StringBuilder("");
+        if (valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
+                .equals(Constants.X_BALLERINA_EVENT_TYPE_HEADER)) {
+            // Handle header event path
+            eventIdentifierType.append(Constants.X_BALLERINA_EVENT_TYPE_HEADER);
+        } else if (valuesMap.get(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
+                .equals(Constants.X_BALLERINA_EVENT_TYPE_BODY)) {
+            // Handle body event path
+            eventIdentifierType.append(Constants.X_BALLERINA_EVENT_TYPE_BODY);
+        } else {
+            throw new BallerinaAsyncApiException(Constants.X_BALLERINA_EVENT_TYPE_HEADER.concat(" or ")
+                    .concat(Constants.X_BALLERINA_EVENT_TYPE_BODY)
+                    .concat(" is not provided as the value of ")
+                    .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER_TYPE)
+                    .concat(" attribute within the attribute "
+                            .concat(Constants.X_BALLERINA_EVENT_FIELD_IDENTIFIER)
+                            .concat(" in the Async API Specification")));
+        }
+        return eventIdentifierType.toString();
+    }
+}

--- a/asyncapi-cli/src/main/resources/dispatcher_service_for_event_identifier_in_header.bal
+++ b/asyncapi-cli/src/main/resources/dispatcher_service_for_event_identifier_in_header.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerinax/asyncapi.native.handler;
+
+service class DispatcherService {
+   *http:Service;
+   private map<GenericServiceType> services = {};
+   private handler:NativeHandler nativeHandler = new ();
+
+   isolated function addServiceRef(string serviceType, GenericServiceType genericService) returns error? {
+        if (self.services.hasKey(serviceType)) {
+             return error("Service of type " + serviceType + " has already been attached");
+        }
+        self.services[serviceType] = genericService;
+   }
+
+   isolated function removeServiceRef(string serviceType) returns error? {
+        if (!self.services.hasKey(serviceType)) {
+             return error("Cannot detach the service of type " + serviceType + ". Service has not been attached to the listener before");
+        }
+        _ = self.services.remove(serviceType);
+   }
+
+   // We are not using the (@http:payload GenericEventWrapperEvent g) notation because of a bug in Ballerina.
+   // Issue: https://github.com/ballerina-platform/ballerina-lang/issues/32859
+   resource function post .(http:Caller caller, http:Request request) returns error? {
+       json payload = check request.getJsonPayload();
+       string eventIdentifier = check request.getHeader("event-identifier-name");
+       GenericDataType genericDataType = check payload.cloneWithType(GenericDataType);
+       check self.matchRemoteFunc(genericDataType, eventIdentifier);
+       check caller->respond(http:STATUS_OK);
+   }
+
+   private function matchRemoteFunc(GenericDataType genericDataType, string eventIdentifier) returns error? {}
+
+   private function executeRemoteFunc(GenericDataType genericEvent, string eventName, string serviceTypeStr, string eventFunction) returns error? {
+         GenericServiceType? genericService = self.services[serviceTypeStr];
+         if genericService is GenericServiceType {
+              check self.nativeHandler.invokeRemoteFunction(genericEvent, eventName, eventFunction, genericService);
+         }
+   }
+}

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/AsyncApiSpecControllerTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/AsyncApiSpecControllerTest.java
@@ -83,6 +83,7 @@ public class AsyncApiSpecControllerTest {
         String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
         SpecController specController = new AsyncApiSpecController(asyncApiSpecJson);
 
-        Assert.assertEquals(specController.getEventIdentifierPath(), "genericDataType.event.'type");
+        Assert.assertEquals(specController.getEventIdentifierType(), "body");
+        Assert.assertEquals(specController.getEventIdentifierPath(), "event.'type");
     }
 }

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherControllerTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherControllerTest.java
@@ -45,7 +45,8 @@ public class DispatcherControllerTest {
         String dispatcherResult = fileRepository
                 .getFileContentFromResources("expected_gen/".concat(Constants.DISPATCHER_SERVICE_BAL_FILE_NAME));
         BalController dispatcherController = new DispatcherController(
-                specController.getServiceTypes(), specController.getEventIdentifierPath());
+                specController.getServiceTypes(), specController.getEventIdentifierType(),
+                specController.getEventIdentifierPath());
         Assert.assertEquals(dispatcherController.generateBalCode(dispatcherTemplate), dispatcherResult);
     }
 
@@ -56,7 +57,7 @@ public class DispatcherControllerTest {
                     "Resource function 'matchRemoteFunc', is not found in the dispatcher_service.bal")
     public void testGenerateWithInvalidTemplate() throws BallerinaAsyncApiException {
         BalController dispatcherController = new DispatcherController(new ArrayList<>(),
-                Constants.CLONE_WITH_TYPE_VAR_NAME);
+                Constants.X_BALLERINA_EVENT_TYPE_BODY, Constants.CLONE_WITH_TYPE_VAR_NAME);
         dispatcherController.generateBalCode("");
     }
 }

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherControllerTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/controller/DispatcherControllerTest.java
@@ -55,7 +55,8 @@ public class DispatcherControllerTest {
             expectedExceptionsMessageRegExp =
                     "Resource function 'matchRemoteFunc', is not found in the dispatcher_service.bal")
     public void testGenerateWithInvalidTemplate() throws BallerinaAsyncApiException {
-        BalController dispatcherController = new DispatcherController(new ArrayList<>(), "");
+        BalController dispatcherController = new DispatcherController(new ArrayList<>(),
+                Constants.CLONE_WITH_TYPE_VAR_NAME);
         dispatcherController.generateBalCode("");
     }
 }

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractHeaderTypeEventIdentifierFromSpecTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractHeaderTypeEventIdentifierFromSpecTest.java
@@ -18,23 +18,6 @@ public class ExtractHeaderTypeEventIdentifierFromSpecTest {
     @Test(
             description = "Test the functionality of the extract function " +
                     "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
-                    "but invalid type attribute value",
-            expectedExceptions = BallerinaAsyncApiException.class,
-            expectedExceptionsMessageRegExp = "header or body is not provided as the value of type attribute within " +
-                    "the attribute x-ballerina-event-identifier in the Async API Specification"
-    )
-    public void testExtractWithIdentifierPathInvalidType() throws BallerinaAsyncApiException {
-        String asyncApiSpecStr = fileRepository
-                .getFileContentFromResources("specs/spec-with-event-identifier-invalid-type.yml");
-        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
-        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
-        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
-        extractIdentifierPathFromSpec.extract();
-    }
-
-    @Test(
-            description = "Test the functionality of the extract function " +
-                    "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
                     "and the value of type attribute as `header` "
     )
     public void testExtractWithIdentifierPathValidHeaderType() throws BallerinaAsyncApiException {

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractHeaderTypeEventIdentifierFromSpecTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractHeaderTypeEventIdentifierFromSpecTest.java
@@ -1,0 +1,68 @@
+package io.ballerina.asyncapi.codegenerator.usecase;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.ballerina.asyncapi.codegenerator.configuration.BallerinaAsyncApiException;
+import io.ballerina.asyncapi.codegenerator.repository.FileRepository;
+import io.ballerina.asyncapi.codegenerator.repository.FileRepositoryImpl;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test the extraction of header type event identifier from the AsyncAPI specification.
+ */
+public class ExtractHeaderTypeEventIdentifierFromSpecTest {
+    FileRepository fileRepository = new FileRepositoryImpl();
+
+    @Test(
+            description = "Test the functionality of the extract function " +
+                    "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
+                    "but invalid type attribute value",
+            expectedExceptions = BallerinaAsyncApiException.class,
+            expectedExceptionsMessageRegExp = "header or body is not provided as the value of type attribute within " +
+                    "the attribute x-ballerina-event-identifier in the Async API Specification"
+    )
+    public void testExtractWithIdentifierPathInvalidType() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-with-event-identifier-invalid-type.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
+        extractIdentifierPathFromSpec.extract();
+    }
+
+    @Test(
+            description = "Test the functionality of the extract function " +
+                    "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
+                    "and the value of type attribute as `header` "
+    )
+    public void testExtractWithIdentifierPathValidHeaderType() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-with-event-identifier-valid-header-type.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
+        String identifierPath = extractIdentifierPathFromSpec.extract();
+
+        Assert.assertEquals(identifierPath, "event-name");
+    }
+
+    @Test(
+            description = "Test the functionality of the extract function " +
+                    "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
+                    "and the value of type attribute as `header` " +
+                    "but missing the name attribute inside it",
+            expectedExceptions = BallerinaAsyncApiException.class,
+            expectedExceptionsMessageRegExp = "name attribute is not found within the attribute " +
+                    "x-ballerina-event-identifier in the Async API Specification"
+    )
+    public void testExtractWithIdentifierPathMissingHeaderName() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-with-event-identifier-missing-header-name.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
+        extractIdentifierPathFromSpec.extract();
+    }
+}

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpecTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierPathFromSpecTest.java
@@ -45,24 +45,7 @@ public class ExtractIdentifierPathFromSpecTest {
         Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
         String identifierPath = extractIdentifierPathFromSpec.extract();
 
-        Assert.assertEquals(identifierPath, "genericDataType.event.'type");
-    }
-
-    @Test(
-            description = "Test the functionality of the extract function " +
-                    "when the Async API spec contains the x-ballerina-identifier-path attribute in the channel " +
-                    "but missing the type attribute inside it",
-            expectedExceptions = BallerinaAsyncApiException.class,
-            expectedExceptionsMessageRegExp = "type attribute is not found within the attribute " +
-                    "x-ballerina-event-identifier in the Async API Specification"
-    )
-    public void testExtractWithIdentifierPathMissingType() throws BallerinaAsyncApiException {
-        String asyncApiSpecStr = fileRepository
-                .getFileContentFromResources("specs/spec-with-identifier-path-missing-type.yml");
-        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
-        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
-        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
-        extractIdentifierPathFromSpec.extract();
+        Assert.assertEquals(identifierPath, "event.'type");
     }
 
     @Test(
@@ -76,22 +59,6 @@ public class ExtractIdentifierPathFromSpecTest {
     public void testExtractWithIdentifierPathMissingPath() throws BallerinaAsyncApiException {
         String asyncApiSpecStr = fileRepository
                 .getFileContentFromResources("specs/spec-with-identifier-path-missing-path.yml");
-        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
-        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
-        Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);
-        extractIdentifierPathFromSpec.extract();
-    }
-
-    @Test(
-            description = "Test the functionality of the extract function when the Async API spec does not contains " +
-                    "the x-ballerina-identifier-path attribute in the channel",
-            expectedExceptions = BallerinaAsyncApiException.class,
-            expectedExceptionsMessageRegExp = "x-ballerina-event-identifier attribute " +
-                    "is not found in the Async API Specification"
-    )
-    public void testExtractWithoutIdentifierPath() throws BallerinaAsyncApiException {
-        String asyncApiSpecStr = fileRepository
-                .getFileContentFromResources("specs/spec-without-identifier-path.yml");
         String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
         AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
         Extractor extractIdentifierPathFromSpec = new ExtractIdentifierPathFromSpec(asyncApiSpec);

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierTypeFromSpecTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/ExtractIdentifierTypeFromSpecTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.usecase;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.ballerina.asyncapi.codegenerator.configuration.BallerinaAsyncApiException;
+import io.ballerina.asyncapi.codegenerator.repository.FileRepository;
+import io.ballerina.asyncapi.codegenerator.repository.FileRepositoryImpl;
+import org.testng.annotations.Test;
+
+/**
+ * Test the extraction of identifier type from the AsyncAPI specification.
+ */
+public class ExtractIdentifierTypeFromSpecTest {
+    FileRepository fileRepository = new FileRepositoryImpl();
+
+    @Test(
+            description = "Test the functionality of the extract function when the Async API spec does not contains " +
+                    "the x-ballerina-identifier-path attribute in the channel",
+            expectedExceptions = BallerinaAsyncApiException.class,
+            expectedExceptionsMessageRegExp = "x-ballerina-event-identifier attribute " +
+                    "is not found in the Async API Specification"
+    )
+    public void testExtractWithoutIdentifierPath() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-without-identifier-path.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierTypeFromSpec = new ExtractIdentifierTypeFromSpec(asyncApiSpec);
+        extractIdentifierTypeFromSpec.extract();
+    }
+
+    @Test(
+            description = "Test the functionality of the extract function " +
+                    "when the Async API spec contains the x-ballerina-identifier-path attribute in the channel " +
+                    "but missing the type attribute inside it",
+            expectedExceptions = BallerinaAsyncApiException.class,
+            expectedExceptionsMessageRegExp = "type attribute is not found within the attribute " +
+                    "x-ballerina-event-identifier in the Async API Specification"
+    )
+    public void testExtractWithIdentifierPathMissingType() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-with-identifier-path-missing-type.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierTypeFromSpec = new ExtractIdentifierTypeFromSpec(asyncApiSpec);
+        extractIdentifierTypeFromSpec.extract();
+    }
+
+    @Test(
+            description = "Test the functionality of the extract function " +
+                    "when the Async API spec contains the x-ballerina-event-identifier attribute in the channel " +
+                    "but invalid type attribute value",
+            expectedExceptions = BallerinaAsyncApiException.class,
+            expectedExceptionsMessageRegExp = "header or body is not provided as the value of type attribute within " +
+                    "the attribute x-ballerina-event-identifier in the Async API Specification"
+    )
+    public void testExtractWithIdentifierPathInvalidType() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-with-event-identifier-invalid-type.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractIdentifierTypeFromSpec = new ExtractIdentifierTypeFromSpec(asyncApiSpec);
+        extractIdentifierTypeFromSpec.extract();
+    }
+}

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/GenerateModuleMemberDeclarationNodeTest.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/codegenerator/usecase/GenerateModuleMemberDeclarationNodeTest.java
@@ -171,4 +171,62 @@ public class GenerateModuleMemberDeclarationNodeTest {
         Generator generateRecordNode = new GenerateModuleMemberDeclarationNode(entry);
         generateRecordNode.generate();
     }
+
+    @Test(description = "Test the functionality of the generate function " +
+            "when there are nullable fields in the schema")
+    public void testGenerateWithNullables() throws BallerinaAsyncApiException {
+        String asyncApiSpecStr = fileRepository
+                .getFileContentFromResources("specs/spec-single-schema-with-x-nullable.yml");
+        String asyncApiSpecJson = fileRepository.convertYamlToJson(asyncApiSpecStr);
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(asyncApiSpecJson);
+        Extractor extractSchemasFromSpec = new ExtractSchemasFromSpec(asyncApiSpec);
+        Map<String, Schema> schemas = extractSchemasFromSpec.extract();
+
+        Iterator<Map.Entry<String, Schema>> iterator = schemas.entrySet().iterator();
+        Map.Entry<String, Schema> firstEntry = iterator.next();
+        Generator generateRecordNode1 = new GenerateModuleMemberDeclarationNode(firstEntry);
+        TypeDefinitionNode typeDefinitionNode1 = generateRecordNode1.generate();
+        Assert.assertEquals(typeDefinitionNode1.typeName().text(), "TotalPriceSet");
+
+        Map.Entry<String, Schema> secondEntry = iterator.next();
+        Generator generateRecordNode2 = new GenerateModuleMemberDeclarationNode(secondEntry);
+        TypeDefinitionNode typeDefinitionNode2 = generateRecordNode2.generate();
+        Assert.assertEquals(typeDefinitionNode2.typeName().text(), "Price");
+
+        Map.Entry<String, Schema> thirdEntry = iterator.next();
+        Generator generateRecordNode3 = new GenerateModuleMemberDeclarationNode(thirdEntry);
+        TypeDefinitionNode typeDefinitionNode3 = generateRecordNode3.generate();
+        Assert.assertEquals(typeDefinitionNode3.typeName().text(), "OrderEvent");
+
+        Map.Entry<String, Schema> forthEntry = iterator.next();
+        Generator generateRecordNode4 = new GenerateModuleMemberDeclarationNode(forthEntry);
+        TypeDefinitionNode typeDefinitionNode4 = generateRecordNode4.generate();
+        Assert.assertEquals(typeDefinitionNode4.typeName().text(), "TaxLine");
+
+        Assert.assertTrue(typeDefinitionNode3.typeDescriptor() instanceof RecordTypeDescriptorNode);
+        RecordTypeDescriptorNode recordTypeDescriptorNode3 =
+                (RecordTypeDescriptorNode) typeDefinitionNode3.typeDescriptor();
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(0)).typeName().toSourceCode(),
+                "TotalPriceSet?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(1)).typeName().toSourceCode(),
+                "TaxLine[]?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(2)).typeName().toSourceCode(),
+                "decimal?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(3)).typeName().toSourceCode(),
+                "record { Priceshop_money?;Price?presentment_money?;} ?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(4)).typeName().toSourceCode(),
+                "int?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(5)).typeName().toSourceCode(),
+                "boolean?");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode3.fields().get(6)).typeName().toSourceCode(),
+                "string?");
+
+        Assert.assertTrue(typeDefinitionNode4.typeDescriptor() instanceof RecordTypeDescriptorNode);
+        RecordTypeDescriptorNode recordTypeDescriptorNode4 =
+                (RecordTypeDescriptorNode) typeDefinitionNode4.typeDescriptor();
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode4.fields().get(2)).typeName().toSourceCode(),
+                "string");
+        Assert.assertEquals(((RecordFieldNode) recordTypeDescriptorNode4.fields().get(3)).typeName().toSourceCode(),
+                "string?");
+    }
 }

--- a/asyncapi-cli/src/test/resources/specs/spec-single-schema-with-x-nullable.yml
+++ b/asyncapi-cli/src/test/resources/specs/spec-single-schema-with-x-nullable.yml
@@ -1,0 +1,77 @@
+asyncapi: 2.1.0
+components:
+  schemas:
+    OrderEvent:
+      properties:
+        id:
+          type: integer
+          description: The ID of the order, used for API purposes. This is different from the order_number property, which is the ID used by the shop owner and customer.
+          x-nullable: true
+        email:
+          type: string
+          description: The customer's email address.
+          x-nullable: true
+        confirmed:
+          type: boolean
+          description: Confirmation status
+          x-nullable: true
+        rate:
+          type: number
+          description: The rate of tax to be applied.
+          x-nullable: true
+        tax_lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxLine'
+          description: An array of tax line objects, each of which details a tax applicable to the order. When creating an order through the API, tax lines can be specified on the order or the line items but not both. Tax lines specified on the order are split across the taxable line items in the created order.
+          x-nullable: true
+        total_price_set:
+          $ref: '#/components/schemas/TotalPriceSet'
+          x-nullable: true
+        total_tax_set:
+          type: object
+          properties:
+            shop_money:
+              $ref: '#/components/schemas/Price'
+            presentment_money:
+              $ref: '#/components/schemas/Price'
+              x-nullable: true
+          description: The total tax applied to the order in shop and presentment currencies.
+          x-nullable: true
+    TaxLine:
+      type: object
+      properties:
+        price:
+          type: string
+          description: The amount of tax to be charged in the shop currency.
+          x-nullable: false
+        rate:
+          type: number
+          description: The rate of tax to be applied.
+        title:
+          type: string
+          description: The name of the tax.
+          x-nullable: true
+        channel_liable:
+          type: boolean
+          description: Whether the channel that submitted the tax line is liable for remitting. A value of null indicates unknown liability for the tax line.
+      description: Tax line object, which details a tax applicable to the order.
+    TotalPriceSet:
+      type: object
+      properties:
+        shop_money:
+          $ref: '#/components/schemas/Price'
+        presentment_money:
+          $ref: '#/components/schemas/Price'
+      description: The total price of the order in shop and presentment currencies.
+    Price:
+      type: object
+      properties:
+        amount:
+          type: string
+          description: The variant's price or compare-at price in the presentment currency.
+        currency_code:
+          type: string
+          description: The three-letter code (ISO 4217 format) for one of the shop's enabled presentment currencies.
+          x-nullable: true
+      description: The price object

--- a/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-invalid-type.yml
+++ b/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-invalid-type.yml
@@ -1,0 +1,5 @@
+asyncapi: 2.1.0
+x-ballerina-event-identifier:
+  type : ""
+  path : "event.type"
+  

--- a/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-missing-header-name.yml
+++ b/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-missing-header-name.yml
@@ -1,0 +1,3 @@
+asyncapi: 2.1.0
+x-ballerina-event-identifier:
+  type : "header"

--- a/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-valid-header-type.yml
+++ b/asyncapi-cli/src/test/resources/specs/spec-with-event-identifier-valid-header-type.yml
@@ -1,0 +1,4 @@
+asyncapi: 2.1.0
+x-ballerina-event-identifier:
+  type : "header"
+  name : "event-name"

--- a/asyncapi-cli/src/test/resources/testng.xml
+++ b/asyncapi-cli/src/test/resources/testng.xml
@@ -33,6 +33,7 @@
             <class name="io.ballerina.asyncapi.codegenerator.usecase.utils.DocCommentsUtilsTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractChannelsFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractIdentifierPathFromSpecTest"/>
+            <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractHeaderTypeEventIdentifierFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractSchemasFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.GenerateListenerStatementNodeTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.GenerateMatchStatementNodeTest"/>

--- a/asyncapi-cli/src/test/resources/testng.xml
+++ b/asyncapi-cli/src/test/resources/testng.xml
@@ -32,6 +32,7 @@
             <class name="io.ballerina.asyncapi.codegenerator.usecase.utils.CodegenUtilsTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.utils.DocCommentsUtilsTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractChannelsFromSpecTest"/>
+            <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractIdentifierTypeFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractIdentifierPathFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractHeaderTypeEventIdentifierFromSpecTest"/>
             <class name="io.ballerina.asyncapi.codegenerator.usecase.ExtractSchemasFromSpecTest"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.1.4-SNAPSHOT
+version=0.1.5-SNAPSHOT
 
 #dependency
 ballerinaLangVersion=2201.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina
-version=0.1.5-SNAPSHOT
+version=0.2.1-SNAPSHOT
 
 #dependency
 ballerinaLangVersion=2201.1.0


### PR DESCRIPTION
## Purpose
>  The AsyncAPI schema doesn't support `nullable` anymore. The idea is that OpenAPI and AsyncAPI will converge into standard JSON Schema in upcoming releases. Please refer [1], [2], [3]. But there are scenarios where the schema fields can be nullable which results in Ballerina data binding issues. Therefore it was decided to give nullable support in the AsyncAPI tool using the `x-nullable: true` extension in AsyncAPI schema. Refer email thread "[Discussion] Improve AsyncAPI tool to support nullable fields in AsyncAPI schema".

[1] https://github.com/asyncapi/spec/pull/204#issuecomment-549943150
[2] https://github.com/asyncapi/generator/issues/33
[3] https://www.asyncapi.com/docs/reference/specification/v2.0.0#schemaObject

```
 x-nullable: true
```

Resolves https://github.com/wso2-enterprise/choreo/issues/13846

## Goals
> Add nullable support

## Approach
> Add nullable support in schema generation

## User stories
> Support scenarios where nullable fields are present in AsyncAPI schema

## Release note
> Add nullable support

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
Ballerina Version: 2201.1.0
Operating System: Ubuntu 20.04
Java SDK: 11