### PR TITLE
Include `http:ListenerConfigurations` to the generated `ListenerConfiguration` record for HTTP webhooks

### DIFF
--- a/asyncapi-cli/src/main/resources/data_types.bal
+++ b/asyncapi-cli/src/main/resources/data_types.bal
@@ -1,2 +1,6 @@
+import ballerina/http;
+
 // Listener related configurations should be included here
-public type ListenerConfigs record {};
+public type ListenerConfiguration record {|
+    *http:ListenerConfiguration;
+|};

--- a/asyncapi-cli/src/main/resources/listener.bal
+++ b/asyncapi-cli/src/main/resources/listener.bal
@@ -7,11 +7,11 @@ public class Listener {
     private http:Listener httpListener;
     private DispatcherService dispatcherService;
 
-    public function init(int|http:Listener listenOn = 8090) returns error? {
-        if listenOn is http:Listener {
-            self.httpListener = listenOn;
+    public function init(int|http:Listener listenTo = 8090, *ListenerConfiguration configuration) returns error? {
+        if listenTo is http:Listener {
+            self.httpListener = listenTo;
         } else {
-            self.httpListener = check new (listenOn);
+            self.httpListener = check new (listenTo, configuration);
         }
         self.dispatcherService = new DispatcherService();
     }

--- a/asyncapi-cli/src/test/resources/expected_gen/data_types.bal
+++ b/asyncapi-cli/src/test/resources/expected_gen/data_types.bal
@@ -1,6 +1,9 @@
+import ballerina/http;
+
 // Listener related configurations should be included here
-public type ListenerConfigs record {
-};
+public type ListenerConfiguration record {|
+    *http:ListenerConfiguration;
+|};
 
 public type CustomTestSchema record {
     string test_id?;

--- a/asyncapi-cli/src/test/resources/expected_gen/listener.bal
+++ b/asyncapi-cli/src/test/resources/expected_gen/listener.bal
@@ -7,11 +7,11 @@ public class Listener {
     private http:Listener httpListener;
     private DispatcherService dispatcherService;
 
-    public function init(int|http:Listener listenOn = 8090) returns error? {
-        if listenOn is http:Listener {
-            self.httpListener = listenOn;
+    public function init(int|http:Listener listenTo = 8090, *ListenerConfiguration configuration) returns error? {
+        if listenTo is http:Listener {
+            self.httpListener = listenTo;
         } else {
-            self.httpListener = check new (listenOn);
+            self.httpListener = check new (listenTo, configuration);
         }
         self.dispatcherService = new DispatcherService();
     }


### PR DESCRIPTION
## Purpose
> Resolves [Provide a way to configure the HTTP Listener configurations in the Async API generated listeners](https://github.com/ballerina-platform/ballerina-library/issues/7493)
