### PR TITLE
Fix: Map received responses to relevant pipe in generated client

### DIFF
--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/GeneratorConstants.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/GeneratorConstants.java
@@ -71,6 +71,7 @@ public class GeneratorConstants {
     public static final String XLIBB = "xlibb";
     public static final String XLIBB_PIPE = "pipe";
     public static final String LOG = "log";
+    public static final String LANG_REGEXP = "lang.regexp";
     public static final String X_DISPATCHER_KEY = "x-dispatcherKey";
     public static final String X_DISPATCHER_STREAM_ID = "x-dispatcherStreamId";
     public static final String CLIENT_CLASS_NAME = "Client";
@@ -80,6 +81,8 @@ public class GeneratorConstants {
     public static final String SPACE = " ";
     public static final String EQUAL_SPACE = " = ";
     public static final String PLUS_SPACE = " + ";
+    public static final String AND_SPACE = " & ";
+    public static final String READONLY = "readonly";
     public static final String NOT = "!";
     public static final String CONNECTION_CLOSE = "connectionClose";
     public static final String CHECK_PATH_FOR_QUERY_PARAM = "check getPathForQueryParam(queryParam)";
@@ -287,6 +290,26 @@ public class GeneratorConstants {
     public static final String PIPE_VAR = PIPE_COLON_PIPE + SPACE + SIMPLE_PIPE;
     public static final String CONNECTION_CLOSE_STATEMENT = "error? connectionClose = self->connectionClose();";
     public static final String CREATE_UUID_STATEMENT = "%s.%s = uuid:createType1AsString();";
+    public static final String RESPONSE_MAP = "responseMap";
+    public static final String PIPE_NAME = "pipeName";
+    public static final String GET_PIPE_NAME_STATEMENT = "string pipeName = self.getPipeName(message.%s);";
+    public static final String GET_PIPE_NAME_TEMPLATE = """
+            private isolated function getPipeName(string responseType) returns string {
+                string responseRecordType = self.getRecordName(responseType);
+                if self.responseMap.hasKey(responseRecordType) {
+                    return self.responseMap.get(responseRecordType);
+                }
+                return responseType;
+            }""";
+    public static final String GET_RECORD_NAME_TEMPLATE = """
+            private isolated function getRecordName(string dispatchingValue) returns string {
+                 string[] words = regexp:split(re `[\\W_]+`, dispatchingValue);
+                 string result = "";
+                 foreach string word in words {
+                     result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+                 }
+                 return result;
+            }""";
     public static final Map<String, String> TYPE_MAP;
 
     static {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/HeaderParam/header_parameter_client.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/HeaderParam/header_parameter_client.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVv1Client {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -28,6 +32,23 @@ public client isolated class PayloadVv1Client {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -75,12 +96,13 @@ public client isolated class PayloadVv1Client {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/HeaderParam/header_with_query.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/HeaderParam/header_with_query.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVv1Client {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -31,6 +35,23 @@ public client isolated class PayloadVv1Client {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -78,12 +99,13 @@ public client isolated class PayloadVv1Client {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/NoServerUrl/missing_server_url.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/NoServerUrl/missing_server_url.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,13 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "ConnectionAckMessage": "connectionInitMessage",
+        "PongMessage": "pingMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +33,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,7 +97,8 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.'type);
+                string pipeName = self.getPipeName(message.'type);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/PathParam/path_param_duplicated_name.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/PathParam/path_param_duplicated_name.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVv1versionversionnameversionnameClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +29,23 @@ public client isolated class PayloadVv1versionversionnameversionnameClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,12 +93,13 @@ public client isolated class PayloadVv1versionversionnameversionnameClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/PathParam/path_parameter_with_special_name.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/PathParam/path_parameter_with_special_name.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVv1versionv2versionnameClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +29,23 @@ public client isolated class PayloadVv1versionv2versionnameClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,12 +93,13 @@ public client isolated class PayloadVv1versionv2versionnameClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/RemoteFunction/remote_function_description.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/RemoteFunction/remote_function_description.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVlocationsClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -24,6 +28,23 @@ public client isolated class PayloadVlocationsClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -71,7 +92,8 @@ public client isolated class PayloadVlocationsClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.event);
+                string pipeName = self.getPipeName(message.event);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/multiple_response_with_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/multiple_response_with_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,10 @@ public client isolated class PayloadVlocationsClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "Response": "request",
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -24,6 +29,23 @@ public client isolated class PayloadVlocationsClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -71,12 +93,13 @@ public client isolated class PayloadVlocationsClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/multiple_response_with_no_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/multiple_response_with_no_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,10 @@ public client isolated class PayloadVlocationsClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "Response": "request",
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -24,6 +29,23 @@ public client isolated class PayloadVlocationsClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -71,7 +93,8 @@ public client isolated class PayloadVlocationsClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.event);
+                string pipeName = self.getPipeName(message.event);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/one_response_with_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/one_response_with_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVlocationsClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -24,6 +28,23 @@ public client isolated class PayloadVlocationsClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -71,12 +92,13 @@ public client isolated class PayloadVlocationsClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.event);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.event);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/one_response_with_no_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SimpleResponse/one_response_with_no_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -8,6 +9,9 @@ public client isolated class PayloadVlocationsClient {
     private final pipe:Pipe writeMessageQueue;
     private final PipesMap pipes;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "UnSubscribe": "subscribe"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -24,6 +28,23 @@ public client isolated class PayloadVlocationsClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -71,7 +92,8 @@ public client isolated class PayloadVlocationsClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.event);
+                string pipeName = self.getPipeName(message.event);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/multiple_stream_with_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/multiple_stream_with_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,13 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "ConnectionAckMessage": "connectionInitMessage",
+        "PongMessage": "pingMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +33,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,12 +97,13 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.'type);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.'type);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/multiple_stream_with_no_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/multiple_stream_with_no_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,13 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "ConnectionAckMessage": "connectionInitMessage",
+        "PongMessage": "pingMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +33,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,7 +97,8 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.'type);
+                string pipeName = self.getPipeName(message.'type);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/one_stream_with_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/one_stream_with_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,11 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +31,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,12 +95,13 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.'type);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.'type);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/one_stream_with_no_dispatcherStreamId.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/StreamResponse/one_stream_with_no_dispatcherStreamId.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,11 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +31,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,7 +95,8 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
-                pipe:Pipe pipe = self.pipes.getPipe(message.'type);
+                string pipeName = self.getPipeName(message.'type);
+                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {
                     log:printError("PipeError: Failed to produce message to the pipe", pipeErr);

--- a/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SubProtocols/graphqloverwebsocket.bal
+++ b/asyncapi-cli/src/test/resources/websockets/asyncapi-to-ballerina/client/baloutputs/SubProtocols/graphqloverwebsocket.bal
@@ -1,3 +1,4 @@
+import ballerina/lang.regexp;
 import ballerina/log;
 import ballerina/websocket;
 
@@ -9,6 +10,13 @@ public client isolated class ChatClient {
     private final PipesMap pipes;
     private final StreamGeneratorsMap streamGenerators;
     private boolean isActive;
+    private final readonly & map<string> responseMap = {
+        "CompleteMessage": "subscribeMessage",
+        "ConnectionAckMessage": "connectionInitMessage",
+        "PongMessage": "pingMessage",
+        "NextMessage": "subscribeMessage",
+        "ErrorMessage": "subscribeMessage"
+    };
 
     # Gets invoked to initialize the `connector`.
     #
@@ -25,6 +33,23 @@ public client isolated class ChatClient {
         self.startMessageWriting();
         self.startMessageReading();
         return;
+    }
+
+    private isolated function getRecordName(string dispatchingValue) returns string {
+        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
+        string result = "";
+        foreach string word in words {
+            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
+        }
+        return result;
+    }
+
+    private isolated function getPipeName(string responseType) returns string {
+        string responseRecordType = self.getRecordName(responseType);
+        if self.responseMap.hasKey(responseRecordType) {
+            return self.responseMap.get(responseRecordType);
+        }
+        return responseType;
     }
 
     # Used to write messages to the websocket.
@@ -72,12 +97,13 @@ public client isolated class ChatClient {
                     self.attemptToCloseConnection();
                     return;
                 }
+                string pipeName = self.getPipeName(message.'type);
                 pipe:Pipe pipe;
                 MessageWithId|error messageWithId = message.cloneWithType(MessageWithId);
                 if messageWithId is MessageWithId {
                     pipe = self.pipes.getPipe(messageWithId.id);
                 } else {
-                    pipe = self.pipes.getPipe(message.'type);
+                    pipe = self.pipes.getPipe(pipeName);
                 }
                 pipe:Error? pipeErr = pipe.produce(message, 5);
                 if pipeErr is pipe:Error {


### PR DESCRIPTION
## Purpose
> $subject

Resolves [WebSocket Client Generated from AsyncAPI Spec Not Working as Expected](https://github.com/ballerina-platform/ballerina-library/issues/7673)

## Approach
To correctly correlate incoming responses with their corresponding requests, a `map` is introduced to maintain the association between request and their respective response handlers (pipes). Upon receiving a response, the client uses the map to look up and pushes the response to the correct pipe.

## Examples

```ballerina
import ballerina/lang.regexp;
import ballerina/log;
import ballerina/websocket;

import xlibb/pipe;

public client isolated class Client {
    // omitted for brevity...
    private final readonly & map<string> responseMap = {
        "ConnectionAckMessage": "connectionInit"
    };

    public isolated function init(websocket:ClientConfiguration clientConfig =  {}, string serviceUrl = "ws://localhost:9090/") returns error? {
        // omitted for brevity...
    }

    private isolated function getRecordName(string dispatchingValue) returns string {
        string[] words = regexp:split(re `[\W_]+`, dispatchingValue);
        string result = "";
        foreach string word in words {
            result += word.substring(0, 1).toUpperAscii() + word.substring(1).toLowerAscii();
        }
        return result;
    }

    private isolated function getPipeName(string responseType) returns string {
        string responseRecordType = self.getRecordName(responseType);
        if self.responseMap.hasKey(responseRecordType) {
            return self.responseMap.get(responseRecordType);
        }
        return responseType;
    }

    private isolated function startMessageReading() {
        worker readMessage {
            while true {
                lock {
                    if !self.isActive {
                        break;
                    }
                }
                Message|websocket:Error message = self.clientEp->readMessage(Message);
                if message is websocket:Error {
                    log:printError("WsError: Failed to read message from the client", message);
                    self.attemptToCloseConnection();
                    return;
                }
                string pipeName = self.getPipeName(message.'type);
                pipe:Pipe pipe = self.pipes.getPipe(pipeName);
                pipe:Error? pipeErr = pipe.produce(message, 5);
                if pipeErr is pipe:Error {
                    log:printError("PipeError: Failed to produce message to the pipe", pipeErr);
                    self.attemptToCloseConnection();
                    return;
                }
            }
        }
    }

    // omitted for brevity...
}
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility