### PR TITLE
Support Spec Generation for `websocket:DispatcherConfig ` Annotation

### DIFF
--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/Constants.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/Constants.java
@@ -41,8 +41,8 @@ public class Constants {
     public static final String WEBSOCKET = "websocket";
     public static final String DISPATCHER_KEY = "dispatcherKey";
     public static final String DISPATCHER_STREAM_ID = "dispatcherStreamId";
-    public static final String DISPATCHER_MAPPING_ANNOTATION = "DispatcherMapping";
-    public static final String ANNOTATION_ATTR_DISPATCHER_VALUE = "value";
+    public static final String DISPATCHER_CONFIG_ANNOTATION = "DispatcherConfig";
+    public static final String ANNOTATION_ATTR_DISPATCHER_VALUE = "dispatcherValue";
     public static final String BALLERINA = "ballerina";
     public static final String TYPEREFERENCE = "typeReference";
     public static final String HTTP_HEADER = "http:Header";

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/Constants.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/Constants.java
@@ -38,6 +38,8 @@ public class Constants {
     public static final String WEBSOCKET = "websocket";
     public static final String DISPATCHER_KEY = "dispatcherKey";
     public static final String DISPATCHER_STREAM_ID = "dispatcherStreamId";
+    public static final String DISPATCHER_MAPPING_ANNOTATION = "DispatcherMapping";
+    public static final String ANNOTATION_ATTR_DISPATCHER_VALUE = "value";
     public static final String BALLERINA = "ballerina";
     public static final String TYPEREFERENCE = "typeReference";
     public static final String HTTP_HEADER = "http:Header";

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -217,7 +217,8 @@ public class AsyncApiRemoteMapper {
                     String functionName = remoteFunctionNode.functionName().toString().trim();
                     if (functionName.matches(CAMEL_CASE_PATTERN)) {
                         if (isRemoteFunctionNameValid(functionName)) {
-                            String remoteRequestTypeName = getDispatcherConfigAnnotatedValue(remoteFunctionNode)
+                            String remoteRequestTypeName =
+                                    getRequestTypeNameFromDispatcherConfigAnnotation(remoteFunctionNode)
                                     .orElse(unescapeIdentifier(functionName.substring(2)));
                             RequiredParameterNode requiredParameterNode =
                                     checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
@@ -371,7 +372,7 @@ public class AsyncApiRemoteMapper {
         return null;
     }
 
-    private Optional<String> getDispatcherConfigAnnotatedValue(FunctionDefinitionNode node) {
+    private Optional<String> getRequestTypeNameFromDispatcherConfigAnnotation(FunctionDefinitionNode node) {
         if (node.metadata().isEmpty()) {
             return Optional.empty();
         }
@@ -380,10 +381,8 @@ public class AsyncApiRemoteMapper {
             if (annotationType.isEmpty()) {
                 continue;
             }
-            if (!annotationType.get().getModule().flatMap(Symbol::getName)
-                    .orElse("").equals(WEBSOCKET) ||
-                    !annotationType.get().getName().orElse("")
-                            .equals(DISPATCHER_CONFIG_ANNOTATION)) {
+            if (!annotationType.get().getModule().flatMap(Symbol::getName) .orElse("").equals(WEBSOCKET) ||
+                    !annotationType.get().getName().orElse("").equals(DISPATCHER_CONFIG_ANNOTATION)) {
                 continue;
             }
             if (annotationNode.annotValue().isEmpty()) {
@@ -391,7 +390,7 @@ public class AsyncApiRemoteMapper {
             }
             MappingConstructorExpressionNode annotationValue = annotationNode.annotValue().get();
             for (Node field : annotationValue.fields()) {
-                if (!field.kind().equals(SyntaxKind.SPECIFIC_FIELD)) {
+                if (!SyntaxKind.SPECIFIC_FIELD.equals(field.kind())) {
                     continue;
                 }
                 String fieldName = ((SpecificFieldNode) field).fieldName().toString().strip();

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -69,7 +69,7 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.ANNOTATION_ATTR_DISPATCHER_VALUE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.CAMEL_CASE_PATTERN;
-import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.DISPATCHER_MAPPING_ANNOTATION;
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.DISPATCHER_CONFIG_ANNOTATION;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.ERROR;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.FALSE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.FRAME_TYPE;
@@ -217,7 +217,7 @@ public class AsyncApiRemoteMapper {
                     String functionName = remoteFunctionNode.functionName().toString().trim();
                     if (functionName.matches(CAMEL_CASE_PATTERN)) {
                         if (isRemoteFunctionNameValid(functionName)) {
-                            String remoteRequestTypeName = getDispatcherMappingAnnotatedValue(remoteFunctionNode)
+                            String remoteRequestTypeName = getDispatcherConfigAnnotatedValue(remoteFunctionNode)
                                     .orElse(unescapeIdentifier(functionName.substring(2)));
                             RequiredParameterNode requiredParameterNode =
                                     checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
@@ -371,7 +371,7 @@ public class AsyncApiRemoteMapper {
         return null;
     }
 
-    private Optional<String> getDispatcherMappingAnnotatedValue(FunctionDefinitionNode node) {
+    private Optional<String> getDispatcherConfigAnnotatedValue(FunctionDefinitionNode node) {
         if (node.metadata().isEmpty()) {
             return Optional.empty();
         }
@@ -383,7 +383,7 @@ public class AsyncApiRemoteMapper {
             if (!annotationType.get().getModule().flatMap(Symbol::getName)
                     .orElse("").equals(WEBSOCKET) ||
                     !annotationType.get().getName().orElse("")
-                            .equals(DISPATCHER_MAPPING_ANNOTATION)) {
+                            .equals(DISPATCHER_CONFIG_ANNOTATION)) {
                 continue;
             }
             if (annotationNode.annotValue().isEmpty()) {

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -217,9 +217,8 @@ public class AsyncApiRemoteMapper {
                     String functionName = remoteFunctionNode.functionName().toString().trim();
                     if (functionName.matches(CAMEL_CASE_PATTERN)) {
                         if (isRemoteFunctionNameValid(functionName)) {
-                            String remoteRequestTypeName =
-                                    getRequestTypeNameFromDispatcherConfigAnnotation(remoteFunctionNode)
-                                            .orElse(unescapeIdentifier(functionName.substring(2)));
+                            String remoteRequestTypeName = getDispatcherTypeFromAnnotation(remoteFunctionNode)
+                                    .orElse(unescapeIdentifier(functionName.substring(2)));
                             RequiredParameterNode requiredParameterNode =
                                     checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
                             //TODO: uncomment after handle onError is capable to have in the server side
@@ -372,7 +371,7 @@ public class AsyncApiRemoteMapper {
         return null;
     }
 
-    private Optional<String> getRequestTypeNameFromDispatcherConfigAnnotation(FunctionDefinitionNode node) {
+    private Optional<String> getDispatcherTypeFromAnnotation(FunctionDefinitionNode node) {
         if (node.metadata().isEmpty()) {
             return Optional.empty();
         }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -22,7 +22,6 @@ import io.apicurio.datamodels.models.asyncapi.v25.AsyncApi25ChannelsImpl;
 import io.apicurio.datamodels.models.asyncapi.v25.AsyncApi25ComponentsImpl;
 import io.apicurio.datamodels.models.asyncapi.v25.AsyncApi25OperationImpl;
 import io.ballerina.asyncapi.websocketscore.generators.asyncspec.model.BalAsyncApi25MessageImpl;
-import io.ballerina.asyncapi.websocketscore.generators.asyncspec.utils.ConverterCommonUtils;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -31,12 +30,14 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.ChildNodeList;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.ParameterNode;
@@ -47,17 +48,21 @@ import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.ANNOTATION_ATTR_DISPATCHER_VALUE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.CAMEL_CASE_PATTERN;
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.DISPATCHER_MAPPING_ANNOTATION;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.FALSE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.FUNCTION_PARAMETERS_EXCEEDED;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.FUNCTION_SIGNATURE_WRONG_TYPE;
@@ -72,6 +77,8 @@ import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constant
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.ON_TEXT_MESSAGE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.REMOTE_DESCRIPTION;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.RETURN;
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.WEBSOCKET;
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.utils.ConverterCommonUtils.unescapeIdentifier;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUALIFIED_NAME_REFERENCE;
 
 /**
@@ -89,6 +96,17 @@ public class AsyncApiRemoteMapper {
      */
     AsyncApiRemoteMapper(SemanticModel semanticModel) {
         this.semanticModel = semanticModel;
+    }
+
+    public static String createCustomRemoteFunctionName(String dispatchingValue) {
+        StringBuilder builder = new StringBuilder();
+        String[] words = dispatchingValue.split("[\\W_]+");
+        for (String word : words) {
+            word = word.isEmpty() ? word : Character.toUpperCase(word.charAt(0)) + word.substring(1)
+                    .toLowerCase(Locale.ENGLISH);
+            builder.append(word);
+        }
+        return builder.toString();
     }
 
     public AsyncApi25ComponentsImpl getComponents() {
@@ -137,7 +155,7 @@ public class AsyncApiRemoteMapper {
                                                          ClassDefinitionNode classDefinitionNode,
                                                          String dispatcherValue,
                                                          AsyncApi25ChannelItemImpl channelItem) {
-        String path = ConverterCommonUtils.unescapeIdentifier(generateRelativePath(resource));
+        String path = unescapeIdentifier(generateRelativePath(resource));
         NodeList<Node> classMethodNodes = classDefinitionNode.members();
         AsyncApi25OperationImpl publishOperationItem = new AsyncApi25OperationImpl();
         AsyncApi25OperationImpl subscribeOperationItem = new AsyncApi25OperationImpl();
@@ -152,8 +170,8 @@ public class AsyncApiRemoteMapper {
                     String functionName = remoteFunctionNode.functionName().toString().trim();
                     if (functionName.matches(CAMEL_CASE_PATTERN)) {
                         if (isRemoteFunctionNameValid(functionName)) {
-                            String remoteRequestTypeName = ConverterCommonUtils.
-                                    unescapeIdentifier(functionName.substring(2));
+                            String remoteRequestTypeName = getDispatcherMappingAnnotatedValue(remoteFunctionNode)
+                                    .orElse(unescapeIdentifier(functionName.substring(2)));
                             RequiredParameterNode requiredParameterNode =
                                     checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
                             //TODO: uncomment after handle onError is capable to have in the server side
@@ -268,7 +286,6 @@ public class AsyncApiRemoteMapper {
         return apiDocs;
     }
 
-
     private RequiredParameterNode checkParameterContainsCustomType(String customTypeName,
                                                                    FunctionDefinitionNode remoteFunctionNode) {
         SeparatedNodeList<ParameterNode> remoteParameters = remoteFunctionNode.functionSignature().parameters();
@@ -293,6 +310,41 @@ public class AsyncApiRemoteMapper {
             }
         }
         return null;
+    }
+
+    private Optional<String> getDispatcherMappingAnnotatedValue(FunctionDefinitionNode node) {
+        if (node.metadata().isEmpty()) {
+            return Optional.empty();
+        }
+        for (AnnotationNode annotationNode : node.metadata().get().annotations()) {
+            Optional<Symbol> annotationType = this.semanticModel.symbol(annotationNode);
+            if (annotationType.isEmpty()) {
+                continue;
+            }
+            if (!annotationType.get().getModule().flatMap(Symbol::getName)
+                    .orElse("").equals(WEBSOCKET) ||
+                    !annotationType.get().getName().orElse("")
+                            .equals(DISPATCHER_MAPPING_ANNOTATION)) {
+                continue;
+            }
+            if (annotationNode.annotValue().isEmpty()) {
+                return Optional.empty();
+            }
+            MappingConstructorExpressionNode annotationValue = annotationNode.annotValue().get();
+            for (Node field : annotationValue.fields()) {
+                if (!field.kind().equals(SyntaxKind.SPECIFIC_FIELD)) {
+                    continue;
+                }
+                String fieldName = ((SpecificFieldNode) field).fieldName().toString().strip();
+                Optional<ExpressionNode> filedValue = ((SpecificFieldNode) field).valueExpr();
+                if (!fieldName.equals(ANNOTATION_ATTR_DISPATCHER_VALUE) || filedValue.isEmpty()) {
+                    continue;
+                }
+                return Optional.of(createCustomRemoteFunctionName(filedValue.get().toString()
+                        .replaceAll("\"", "").strip()));
+            }
+        }
+        return Optional.empty();
     }
 
     private String getServiceClassName(FunctionDefinitionNode resource) {

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -397,11 +397,11 @@ public class AsyncApiRemoteMapper {
                     continue;
                 }
                 String fieldName = ((SpecificFieldNode) field).fieldName().toString().strip();
-                Optional<ExpressionNode> filedValue = ((SpecificFieldNode) field).valueExpr();
-                if (!fieldName.equals(ANNOTATION_ATTR_DISPATCHER_VALUE) || filedValue.isEmpty()) {
+                Optional<ExpressionNode> fieldValue = ((SpecificFieldNode) field).valueExpr();
+                if (!fieldName.equals(ANNOTATION_ATTR_DISPATCHER_VALUE) || fieldValue.isEmpty()) {
                     continue;
                 }
-                return Optional.of(createCustomRemoteFunctionName(filedValue.get().toString()
+                return Optional.of(createCustomRemoteFunctionName(fieldValue.get().toString()
                         .replaceAll("\"", "").strip()));
             }
         }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -219,7 +219,7 @@ public class AsyncApiRemoteMapper {
                         if (isRemoteFunctionNameValid(functionName)) {
                             String remoteRequestTypeName =
                                     getRequestTypeNameFromDispatcherConfigAnnotation(remoteFunctionNode)
-                                    .orElse(unescapeIdentifier(functionName.substring(2)));
+                                            .orElse(unescapeIdentifier(functionName.substring(2)));
                             RequiredParameterNode requiredParameterNode =
                                     checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
                             //TODO: uncomment after handle onError is capable to have in the server side
@@ -381,7 +381,7 @@ public class AsyncApiRemoteMapper {
             if (annotationType.isEmpty()) {
                 continue;
             }
-            if (!annotationType.get().getModule().flatMap(Symbol::getName) .orElse("").equals(WEBSOCKET) ||
+            if (!annotationType.get().getModule().flatMap(Symbol::getName).orElse("").equals(WEBSOCKET) ||
                     !annotationType.get().getName().orElse("").equals(DISPATCHER_CONFIG_ANNOTATION)) {
                 continue;
             }

--- a/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
+++ b/asyncapi-cli/src/main/java/io/ballerina/asyncapi/websocketscore/generators/asyncspec/service/AsyncApiRemoteMapper.java
@@ -88,13 +88,13 @@ import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constant
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.ON_TEXT_MESSAGE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.REMOTE_DESCRIPTION;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.RETURN;
+import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.WEBSOCKET;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_PATH;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_PATH_FRAME_TYPE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_TYPE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_TYPE_BODY;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE_CLOSE;
-import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.Constants.WEBSOCKET;
 import static io.ballerina.asyncapi.websocketscore.generators.asyncspec.utils.ConverterCommonUtils.unescapeIdentifier;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUALIFIED_NAME_REFERENCE;
 
@@ -190,10 +190,11 @@ public class AsyncApiRemoteMapper {
 
     /**
      * Remote mapper when there have multiple remote methods.
-     * @param resource functionDefinitionNode which contains resource function
+     *
+     * @param resource            functionDefinitionNode which contains resource function
      * @param classDefinitionNode classDefinitionNode which contains class definition
-     * @param dispatcherValue dispatcher key value
-     * @param channelItem AsyncAPI channel
+     * @param dispatcherValue     dispatcher key value
+     * @param channelItem         AsyncAPI channel
      * @return AsyncAPI channel object
      */
     private AsyncApi25ChannelsImpl handleRemoteFunctions(FunctionDefinitionNode resource,

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/cmd/BallerinaToAsyncApiWsTests.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/cmd/BallerinaToAsyncApiWsTests.java
@@ -200,7 +200,7 @@ public class BallerinaToAsyncApiWsTests extends AsyncApiWsCommandTest {
     }
 
     @Test(description = "Test ballerina to asyncApi with dispatcher mapping annotation")
-    public void asyncApiGenerationWithDispatcherMappingAnnotation() {
+    public void asyncApiGenerationWithDispatcherConfigAnnotation() {
         String fileName = "listener";
         String fileDirectory = "ballerina-to-asyncapi/dispatcher-mapping-annotation/";
         Path filePath = resourceDir.resolve(Paths.get(fileDirectory + fileName + ".bal"));

--- a/asyncapi-cli/src/test/java/io/ballerina/asyncapi/cmd/BallerinaToAsyncApiWsTests.java
+++ b/asyncapi-cli/src/test/java/io/ballerina/asyncapi/cmd/BallerinaToAsyncApiWsTests.java
@@ -96,6 +96,24 @@ public class BallerinaToAsyncApiWsTests extends AsyncApiWsCommandTest {
         }
     }
 
+    @Test(description = "Test ballerina to asyncApi with dispatcher mapping annotation")
+    public void asyncApiGenerationWithDispatcherMappingAnnotation() {
+        String fileName = "listener";
+        String fileDirectory = "ballerina-to-asyncapi/dispatcher-mapping-annotation/";
+        Path filePath = resourceDir.resolve(Paths.get(fileDirectory + fileName + ".bal"));
+        String[] args = {"--input", filePath.toString(), "-o", this.tmpDir.toString(), "--protocol", "ws"};
+        AsyncApiCmd cmd = new AsyncApiCmd(tmpDir, false);
+        new CommandLine(cmd).parseArgs(args);
+        try {
+            cmd.execute();
+            String generatedAsyncAPI = getStringFromGivenBalFile(this.tmpDir.resolve(fileName + "_asyncapi.yaml"));
+            String expectedYaml = getStringFromGivenBalFile(
+                    this.resourceDir.resolve(fileDirectory + "expected_gen/" + fileName + ".yaml"));
+            Assert.assertEquals(expectedYaml, generatedAsyncAPI);
+        } catch (BLauncherException | IOException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
 
     @Test(description = "AsyncAPI Annotation with ballerina to asyncapi", enabled = false)
     public void asyncapiAnnotationWithContract() {

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/expected_gen/listener.yaml
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/expected_gen/listener.yaml
@@ -16,8 +16,7 @@ channels:
   /:
     subscribe:
       message:
-        payload:
-          type: string
+        $ref: '#/components/messages/SubscribeResponse'
     publish:
       message:
         $ref: '#/components/messages/Subscribe'
@@ -31,12 +30,24 @@ components:
         type:
           type: string
           const: Subscribe
+    SubscribeResponse:
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
   messages:
+    SubscribeResponse:
+      payload:
+        $ref: '#/components/schemas/SubscribeResponse'
     Subscribe:
       payload:
         $ref: '#/components/schemas/Subscribe'
       x-response:
-        payload:
-          type: string
+        $ref: '#/components/messages/SubscribeResponse'
       x-response-type: simple-rpc
 x-dispatcherKey: type

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/expected_gen/listener.yaml
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/expected_gen/listener.yaml
@@ -1,0 +1,42 @@
+asyncapi: 2.5.0
+info:
+  title: /
+  version: 0.0.0
+servers:
+  development:
+    url: "{server}:{port}/"
+    protocol: ws
+    protocolVersion: "13"
+    variables:
+      server:
+        default: ws://localhost
+      port:
+        default: "9090"
+channels:
+  /:
+    subscribe:
+      message:
+        payload:
+          type: string
+    publish:
+      message:
+        $ref: '#/components/messages/Subscribe'
+components:
+  schemas:
+    Subscribe:
+      type: object
+      required:
+      - type
+      properties:
+        type:
+          type: string
+          const: Subscribe
+  messages:
+    Subscribe:
+      payload:
+        $ref: '#/components/schemas/Subscribe'
+      x-response:
+        payload:
+          type: string
+      x-response-type: simple-rpc
+x-dispatcherKey: type

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
@@ -1,0 +1,30 @@
+import ballerina/websocket;
+
+listener websocket:Listener websocketListener = check new (9090);
+
+type Subscribe record {|
+    string 'type;
+|};
+
+type ConnectionAck record {|
+    string 'type;
+    map<json> payload?;
+|};
+
+@websocket:ServiceConfig {dispatcherKey: "type"}
+service / on websocketListener {
+    resource function get .() returns websocket:Service|websocket:UpgradeError {
+        return new WsService();
+    }
+}
+
+service class WsService {
+    *websocket:Service;
+
+    @websocket:DispatcherMapping {
+        value: "subscribe"
+    }
+    remote function onSubscribeMessage(Subscribe message) returns string {
+        return "onSubscribeMessage";
+    }
+}

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
@@ -21,8 +21,8 @@ service / on websocketListener {
 service class WsService {
     *websocket:Service;
 
-    @websocket:DispatcherMapping {
-        value: "subscribe"
+    @websocket:DispatcherConfig {
+        dispatcherValue: "subscribe"
     }
     remote function onSubscribeMessage(Subscribe message) returns SubscribeResponse {
         return {'type: "subscribe"};

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
@@ -6,7 +6,7 @@ type Subscribe record {|
     string 'type;
 |};
 
-type ConnectionAck record {|
+type SubscribeResponse record {|
     string 'type;
     map<json> payload?;
 |};
@@ -24,7 +24,7 @@ service class WsService {
     @websocket:DispatcherMapping {
         value: "subscribe"
     }
-    remote function onSubscribeMessage(Subscribe message) returns string {
-        return "onSubscribeMessage";
+    remote function onSubscribeMessage(Subscribe message) returns SubscribeResponse {
+        return {'type: "subscribe"};
     }
 }

--- a/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
+++ b/asyncapi-cli/src/test/resources/websockets/ballerina-to-asyncapi/dispatcher-mapping-annotation/listener.bal
@@ -1,3 +1,19 @@
+//  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+//
+//  WSO2 LLC. licenses this file to you under the Apache License,
+//  Version 2.0 (the "License"); you may not use this file except
+//  in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import ballerina/websocket;
 
 listener websocket:Listener websocketListener = check new (9090);

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ stdlibOAuth2Version=2.14.0
 stdlibHttpVersion=2.14.0
 
 # Stdlib Level 06
-stdlibWebsocketVersion=2.14.0
+stdlibWebsocketVersion=2.15.0-20250411-131900-4b939e7
 
 # Ballerinax
 stdlibKafkaVersion=4.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ stdlibOAuth2Version=2.14.0
 stdlibHttpVersion=2.14.0
 
 # Stdlib Level 06
-stdlibWebsocketVersion=2.15.0-20250411-131900-4b939e7
+stdlibWebsocketVersion=2.15.0-20250430-104500-06d1dfd
 
 # Ballerinax
 stdlibKafkaVersion=4.5.0


### PR DESCRIPTION
## Purpose
Adds support for generating correct AsyncAPI specifications when custom remote function mappings are defined using annotations in the WebSocket module.

Part of [Support Custom Remote Function Mapping via Annotation](https://github.com/ballerina-platform/ballerina-library/issues/7733)

## Samples
### Sample ballerina service
```ballerina
import ballerina/websocket;

listener websocket:Listener websocketListener = check new (9090);

type Subscribe record {|
    string 'type;
|};

type SubscribeResponse record {|
    string 'type;
    map<json> payload?;
|};

@websocket:ServiceConfig {dispatcherKey: "type"}
service / on websocketListener {
    resource function get .() returns websocket:Service|websocket:UpgradeError {
        return new WsService();
    }
}

service class WsService {
    *websocket:Service;

    @websocket:DispatcherConfig {
        dispatcherValue: "subscribe"
    }
    remote function onSubscribeMessage(Subscribe message) returns SubscribeResponse {
        return {'type: "subscribe"};
    }
}
```

### Expected AsyncAPI spec
```yaml
asyncapi: 2.5.0
info:
  title: /
  version: 0.1.0
servers:
  development:
    url: "{server}:{port}/"
    protocol: ws
    protocolVersion: "13"
    variables:
      server:
        default: ws://localhost
      port:
        default: "9090"
channels:
  /:
    subscribe:
      message:
        $ref: '#/components/messages/SubscribeResponse'
    publish:
      message:
        $ref: '#/components/messages/Subscribe'
components:
  schemas:
    Subscribe:
      type: object
      required:
      - type
      properties:
        type:
          type: string
          const: Subscribe
    SubscribeResponse:
      type: object
      required:
      - type
      properties:
        type:
          type: string
        payload:
          type: object
          additionalProperties: true
  messages:
    SubscribeResponse:
      payload:
        $ref: '#/components/schemas/SubscribeResponse'
    Subscribe:
      payload:
        $ref: '#/components/schemas/Subscribe'
      x-response:
        $ref: '#/components/messages/SubscribeResponse'
      x-response-type: simple-rpc
x-dispatcherKey: type
```