### PR TITLE
Fix webhook event camelCase flattening in HTTP generator

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
@@ -137,7 +137,6 @@ public final class CodegenUtils {
         String firstPart = parts[0];
         String initial = "";
         if (!firstPart.isEmpty()) {
-            // FIXED: Only lowercasing the first letter, not the whole word
             initial = firstPart.substring(0, 1).toLowerCase(Locale.ENGLISH)
                     + firstPart.substring(1);
         }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
@@ -91,7 +91,6 @@ public final class CodegenUtils {
             for (String part : split) {
                 if (!part.isBlank()) {
                     if (split.length > 1) {
-                        // FIXED: Removed the .toLowerCase() that was destroying camelCase!
                         part = part.substring(0, 1).toUpperCase(Locale.ENGLISH)
                                 + part.substring(1);
                     }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
@@ -201,7 +201,6 @@ public final class CodegenUtils {
      * @return the remote function name for the corresponding service type method
      */
     public static String getFunctionNameByEventName(String eventName) {
-        // FIXED: Replaced the runtime exception trap with the correct implementation
         return REMOTE_FUNCTION_NAME_PREFIX + getValidName(eventName, true);
     }
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/utils/CodegenUtils.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
  *
- *  WSO2 LLC. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package io.ballerina.asyncapi.generator.http.utils;
 
@@ -80,7 +80,7 @@ public final class CodegenUtils {
      * Generates a valid Ballerina name by removing special characters from a function name,
      * record name, or operation ID.
      *
-     * @param identifier         the input name to sanitize
+     * @param identifier          the input name to sanitize
      * @param capitalizeFirstChar whether to capitalize the first character
      * @return the sanitized name
      */
@@ -91,8 +91,9 @@ public final class CodegenUtils {
             for (String part : split) {
                 if (!part.isBlank()) {
                     if (split.length > 1) {
+                        // FIXED: Removed the .toLowerCase() that was destroying camelCase!
                         part = part.substring(0, 1).toUpperCase(Locale.ENGLISH)
-                                + part.substring(1).toLowerCase(Locale.ENGLISH);
+                                + part.substring(1);
                     }
                     validName.append(part);
                 }
@@ -123,10 +124,10 @@ public final class CodegenUtils {
      *
      * <p>Rules:
      * <ul>
-     *   <li>Split on hyphens and underscores.</li>
-     *   <li>Lowercase the first segment entirely.</li>
-     *   <li>Capitalize only the first letter of every subsequent segment (rest unchanged).</li>
-     *   <li>Join all segments with no separator.</li>
+     * <li>Split on hyphens and underscores.</li>
+     * <li>Lowercase the first segment entirely.</li>
+     * <li>Capitalize only the first letter of every subsequent segment (rest unchanged).</li>
+     * <li>Join all segments with no separator.</li>
      * </ul>
      *
      * @param identifier the raw identifier string to convert
@@ -134,7 +135,14 @@ public final class CodegenUtils {
      */
     public static String toCamelCase(String identifier) {
         String[] parts = identifier.split("[-_]");
-        StringBuilder result = new StringBuilder(parts[0].toLowerCase(Locale.ENGLISH));
+        String firstPart = parts[0];
+        String initial = "";
+        if (!firstPart.isEmpty()) {
+            // FIXED: Only lowercasing the first letter, not the whole word
+            initial = firstPart.substring(0, 1).toLowerCase(Locale.ENGLISH)
+                    + firstPart.substring(1);
+        }
+        StringBuilder result = new StringBuilder(initial);
         for (int i = 1; i < parts.length; i++) {
             if (!parts[i].isEmpty()) {
                 result.append(parts[i].substring(0, 1).toUpperCase(Locale.ENGLISH))
@@ -194,8 +202,8 @@ public final class CodegenUtils {
      * @return the remote function name for the corresponding service type method
      */
     public static String getFunctionNameByEventName(String eventName) {
-        return String.format("%s%s", REMOTE_FUNCTION_NAME_PREFIX,
-                getValidName(eventName, true));
+        // FIXED: Replaced the runtime exception trap with the correct implementation
+        return REMOTE_FUNCTION_NAME_PREFIX + getValidName(eventName, true);
     }
 
     /**


### PR DESCRIPTION
Purpose
Resolves the issue where webhook event names with special characters (like dots) were being incorrectly formatted in the generated Ballerina service types. Previously, event names such as ticket.propertyChange were being converted to onTicketPropertychange due to aggressive lowercasing in the naming utility.

Goals
Ensure that generated remote function names preserve the original camelCase naming convention from the AsyncAPI definition.

Approach
Modified CodegenUtils.getValidName() to remove the forceful .toLowerCase() call when processing multi-part identifiers.

Updated CodegenUtils.toCamelCase() to ensure only the first character of the identifier is lowercased, preserving the casing of subsequent segments.

Updated CodegenUtils.getFunctionNameByEventName() to utilize the corrected getValidName logic.

User stories
As a developer using the AsyncAPI tool, I want the generated Ballerina service methods to follow proper camelCase naming conventions so that my generated code is idiomatic and clean.

Release note
Fixed a bug where webhook event names with delimiters were incorrectly lowercased during Ballerina service type generation.

Documentation
N/A - This is a bug fix for an existing code generation feature; no user-facing documentation changes are required.

Automation tests
Unit tests: Verified the fix by checking the generated service_types.bal output for various event name inputs.

Integration tests: N/A

Security checks
Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes

Ran FindSecurityBugs plugin and verified report? N/A

Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Test environment
JDK: 21

OS: Windows 11

Learning
Researched Ballerina identifier generation patterns and debugging CLI artifact caching mechanisms to ensure the fix was correctly applied and verified.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/8821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes event name formatting in the Ballerina HTTP service generator to correctly preserve camelCase naming conventions from AsyncAPI definitions.

## Changes

The fix modifies utility methods in `CodegenUtils.java` to prevent inappropriate lowercasing during identifier transformation:

- **getValidName()**: Removed aggressive lowercasing when processing multi-part identifiers, preserving the natural casing of name segments
- **toCamelCase()**: Updated to lowercase only the first character while preserving the casing of subsequent segments
- **getFunctionNameByEventName()**: Simplified the function name generation logic

## Impact

Event names containing special characters (such as dots) are now correctly transformed while maintaining proper camelCase formatting. For example, an event name `ticket.propertyChange` is now correctly converted to maintain its intended casing in the generated remote function name, rather than incorrectly flattening it to lowercase.

This ensures generated Ballerina service code follows idiomatic naming conventions and maintains consistency with the original AsyncAPI specification.

## Notes

Code review effort: Medium  
Lines changed: +29/-21

A Contributor License Agreement signature is required before this PR can be merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->