### PR TITLE
Match --service filter against class-based service names in WS spec generation

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
@@ -38,11 +38,8 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
-import io.ballerina.compiler.syntax.tree.ChildNodeList;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
-import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
-import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
@@ -52,13 +49,11 @@ import io.ballerina.compiler.syntax.tree.ParameterNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.ResourcePathParameterNode;
-import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -100,6 +95,7 @@ import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_TYPE_BODY;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE_CLOSE;
+import static io.ballerina.asyncapi.generator.ws.asyncspec.utils.ConverterCommonUtils.getServiceClassName;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.utils.ConverterCommonUtils.unescapeIdentifier;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUALIFIED_NAME_REFERENCE;
 
@@ -507,24 +503,6 @@ public class AsyncApiRemoteMapper {
             }
         }
         return Optional.empty();
-    }
-
-    private String getServiceClassName(FunctionDefinitionNode resource) {
-        String serviceClassName = "";
-        FunctionBodyNode functionBodyNode = resource.functionBody();
-        ChildNodeList childNodeList = functionBodyNode.children();
-        for (Node node : childNodeList) {
-            if (node instanceof ReturnStatementNode) {
-                ReturnStatementNode returnStatementNode = (ReturnStatementNode) node;
-                Optional<ExpressionNode> expression = returnStatementNode.expression();
-                if (expression.get() instanceof ExplicitNewExpressionNode) {
-                    ExplicitNewExpressionNode explicitNewExpressionNode = (ExplicitNewExpressionNode) expression.get();
-                    TypeDescriptorNode typeDescriptorNode = explicitNewExpressionNode.typeDescriptor();
-                    serviceClassName = typeDescriptorNode.toString().trim();
-                }
-            }
-        }
-        return serviceClassName;
     }
 
     private Map<String, ReturnTypeDescriptorNode> getReturnTypesFromOnErrorMethods(

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/utils/ConverterCommonUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/utils/ConverterCommonUtils.java
@@ -43,8 +43,16 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ChildNodeList;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
@@ -310,6 +318,32 @@ public final class ConverterCommonUtils {
                     ((TypeReferenceTypeSymbol) listenerType).typeDescriptor().getModule().get());
         }
         return false;
+    }
+
+    /**
+     * Resolves the service-class name a WebSocket upgrade resource returns, e.g. {@code ChatService}
+     * for {@code resource function get .() returns websocket:Service|websocket:UpgradeError {
+     * return new ChatService(); }}.
+     *
+     * @param resource the upgrade resource function definition node
+     * @return the resolved class name, or an empty string if the resource doesn't return a
+     *         {@code new <ClassName>(...)} expression
+     */
+    public static String getServiceClassName(FunctionDefinitionNode resource) {
+        String serviceClassName = "";
+        FunctionBodyNode functionBodyNode = resource.functionBody();
+        ChildNodeList childNodeList = functionBodyNode.children();
+        for (Node node : childNodeList) {
+            if (node instanceof ReturnStatementNode returnStatementNode) {
+                Optional<ExpressionNode> expression = returnStatementNode.expression();
+                if (expression.isPresent() && expression.get() instanceof ExplicitNewExpressionNode
+                        explicitNewExpressionNode) {
+                    TypeDescriptorNode typeDescriptorNode = explicitNewExpressionNode.typeDescriptor();
+                    serviceClassName = typeDescriptorNode.toString().trim();
+                }
+            }
+        }
+        return serviceClassName;
     }
 
     private static boolean isWebsocketModule(ModuleSymbol moduleSymbol) {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/utils/ServiceToAsyncApiConverterUtils.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/utils/ServiceToAsyncApiConverterUtils.java
@@ -35,6 +35,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
@@ -159,13 +160,15 @@ public final class ServiceToAsyncApiConverterUtils {
                     Optional<Symbol> serviceSymbol = semanticModel.symbol(serviceNode);
                     if (serviceSymbol.isPresent() && serviceSymbol.get() instanceof ServiceDeclarationSymbol) {
                         String service = AsyncApiEndpointMapper.ENDPOINT_MAPPER.getServiceBasePath(serviceNode);
+                        String serviceClassName = resolveServiceClassName(serviceNode);
                         String updateServiceName = service;
                         if (servicesToGenerate.containsKey(service)) {
                             updateServiceName = service + HYPHEN + serviceSymbol.get().hashCode();
                         }
                         if (serviceName != null) {
-                            availableService.add(service);
-                            if (serviceName.equals(service)) {
+                            availableService.add(serviceClassName.isEmpty()
+                                    ? service : service + " (" + serviceClassName + ")");
+                            if (serviceName.equals(service) || serviceName.equals(serviceClassName)) {
                                 servicesToGenerate.put(updateServiceName, serviceNode);
                             }
                         } else {
@@ -177,6 +180,29 @@ public final class ServiceToAsyncApiConverterUtils {
                 classDefinitionNodes.add((ClassDefinitionNode) node);
             }
         }
+    }
+
+    /**
+     * Resolves the class-based service name for an anonymous service declaration by inspecting
+     * its upgrade resource (e.g. {@code resource function get .()}) for a {@code return new
+     * ChatService();} expression. Anonymous services matched only by base path (e.g. {@code /chat})
+     * have no name of their own from a caller's perspective - the class they upgrade into is what
+     * a {@code --service} filter is actually expected to match against.
+     *
+     * @param serviceNode the anonymous service declaration node
+     * @return the resolved class name, or an empty string if none could be resolved
+     */
+    private static String resolveServiceClassName(ServiceDeclarationNode serviceNode) {
+        for (Node member : serviceNode.members()) {
+            if (member.kind().equals(SyntaxKind.RESOURCE_ACCESSOR_DEFINITION)) {
+                String serviceClassName =
+                        ConverterCommonUtils.getServiceClassName((FunctionDefinitionNode) member);
+                if (!serviceClassName.isEmpty()) {
+                    return serviceClassName;
+                }
+            }
+        }
+        return "";
     }
 
     /**

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
@@ -594,6 +594,13 @@ class BallerinaToAsyncApiGeneratorTest {
                 balFile, outDir, null, needJson, System.out);
     }
 
+    private List<AsyncApiConverterDiagnostic> runWithServiceName(String source, String serviceName)
+            throws IOException {
+        Path balFile = writeBalSource(source);
+        return BallerinaToAsyncApiGenerator.generateAsyncAPIDefinitionsAllService(
+                balFile, outDir, serviceName, false, System.out);
+    }
+
     private String readFile(String fileName) throws IOException {
         return Files.readString(outDir.resolve(fileName));
     }
@@ -638,6 +645,19 @@ class BallerinaToAsyncApiGeneratorTest {
                 "remoteRequestTypeName 'ChatMessage' (onChatMessage.substring(2)) must appear in spec");
         Assert.assertTrue(yaml.contains("sendChatMessage"),
                 "send operation 'sendChatMessage' must appear in spec");
+    }
+
+    @Test
+    void testServiceNameFilter_matchesClassBasedServiceName() throws IOException {
+        // Reproduces #8713: `--service ChatService` must match the class-based service name
+        // (the name a user actually knows their service by), not just the anonymous service's
+        // base path ("/chat"), which is all AAS_CONVERTOR_101's matching currently checks.
+        List<AsyncApiConverterDiagnostic> diagnostics = runWithServiceName(BAL_ONE_REMOTE, "ChatService");
+        Assert.assertTrue(diagnostics.isEmpty(),
+                "generator must find the service by its class-based name 'ChatService', not just its "
+                        + "base path '/chat'. Diagnostics: " + diagnostics);
+        Assert.assertTrue(Files.exists(outDir.resolve("chat_asyncapi.yaml")),
+                "output file chat_asyncapi.yaml must be created when filtering by service name 'ChatService'");
     }
 
     @Test


### PR DESCRIPTION
## Purpose
`bal asyncapi --protocol ws --service <name>` fails to find WebSocket services that are identified by their class-based name (e.g. `ChatService`) rather than their base path (e.g. `/chat`), even when the service exists and is correctly wired up. The filter only ever compared the given name against the service's URL path, never against the class it upgrades into.

Resolves: https://github.com/ballerina-platform/ballerina-library/issues/8713

## Goals
Allow `--service <name>` to match a WebSocket service by the class name it upgrades into, in addition to the existing base-path matching, so users can reference a service by the name they actually know it by. Also make the "no service found" diagnostic list the actual matchable identifiers instead of only base paths.

## Approach
Extracted the existing class-name resolution logic (previously private and only used internally by `AsyncApiRemoteMapper` for message mapping) into a shared `ConverterCommonUtils.getServiceClassName()` helper. Added `resolveServiceClassName()` in `ServiceToAsyncApiConverterUtils` to walk a service's upgrade resource and resolve the class it returns. The `--service` filter now checks the given name against both the base path and the resolved class name, and the "available services" diagnostic shows both (e.g. `/chat (ChatService)`).

## User stories
As a developer with an existing WebSocket service written as a class (e.g. `ChatService`), I want to generate an AsyncAPI spec for just that service using `--service ChatService`, so that I don't have to generate specs for every service in the file or guess at an internal path-based identifier.

## Release note
Fixed `bal asyncapi --protocol ws --service <name>` failing to find WebSocket services identified by their class-based name instead of their base path.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  New regression test `testServiceNameFilter_matchesClassBasedServiceName` added, reusing the existing `ChatService` fixture. No formal coverage percentage tracked for this module.
- Integration tests
  Full `asyncapi-generator` test suite (330/330) and checkstyle pass with no regressions.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A 

## Related PRs
See also the PR for #6601 - both touch `AsyncApiRemoteMapper.java` in the same WS spec-generation subsystem, but are independent fixes with no overlap in changed methods.

## Migrations (if applicable)
N/A

## Test environment
## Test environment
JDK 21 (Temurin 21.0.2), Windows 11, Ballerina distribution 2201.13.0. 

