### PR TITLE
Derive WS remote function's message type from its parameter, not its function name

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
@@ -269,12 +269,13 @@ public class AsyncApiRemoteMapper {
                         if (isRemoteFunctionNameValid(functionName)) {
                             Optional<NodeList<AnnotationNode>> annotationNodes =
                                     remoteFunctionNode.metadata().map(MetadataNode::annotations);
-                            String remoteRequestTypeName = annotationNodes
-                                    .flatMap(this::getDispatcherTypeFromAnnotation)
-                                    .orElseGet(() -> unescapeIdentifier(functionName.substring(2)));
+                            Optional<String> dispatcherTypeOverride =
+                                    annotationNodes.flatMap(this::getDispatcherTypeFromAnnotation);
                             RequiredParameterNode requiredParameterNode =
-                                    checkParameterContainsCustomType(remoteRequestTypeName, remoteFunctionNode);
+                                    findCustomTypeParameter(remoteFunctionNode);
                             if (requiredParameterNode != null) {
+                                String remoteRequestTypeName = dispatcherTypeOverride.orElseGet(() ->
+                                        unescapeIdentifier(resolveParameterTypeName(requiredParameterNode)));
                                 String paramName = requiredParameterNode.paramName().get().toString().trim();
                                 Node parameterTypeNode = requiredParameterNode.typeName();
                                 TypeSymbol remoteFunctionNameTypeSymbol = (TypeSymbol) semanticModel.
@@ -450,30 +451,42 @@ public class AsyncApiRemoteMapper {
         return apiDocs;
     }
 
-    private RequiredParameterNode checkParameterContainsCustomType(String customTypeName,
-                                                                   FunctionDefinitionNode remoteFunctionNode) {
+    /**
+     * Finds the remote function's data parameter - the first required parameter whose type is a
+     * named reference to a custom (record) type. The function's own name plays no part in this;
+     * only the parameter's actual declared type determines what gets generated.
+     *
+     * @param remoteFunctionNode the remote function definition node
+     * @return the resolved parameter node, or {@code null} if none of the required parameters
+     *         reference a named custom type
+     */
+    private RequiredParameterNode findCustomTypeParameter(FunctionDefinitionNode remoteFunctionNode) {
         SeparatedNodeList<ParameterNode> remoteParameters = remoteFunctionNode.functionSignature().parameters();
         for (ParameterNode remoteParameterNode : remoteParameters) {
             if (remoteParameterNode.kind() == SyntaxKind.REQUIRED_PARAM) {
                 RequiredParameterNode requiredParameterNode = (RequiredParameterNode) remoteParameterNode;
                 Node parameterTypeNode = requiredParameterNode.typeName();
-                if (parameterTypeNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
-                    SimpleNameReferenceNode simpleNameReferenceNode = (SimpleNameReferenceNode) parameterTypeNode;
-                    String simpleType = simpleNameReferenceNode.name().toString().trim();
-                    if (simpleType.equals(customTypeName)) {
-                        return requiredParameterNode;
-                    }
-                } else if (parameterTypeNode.kind() == QUALIFIED_NAME_REFERENCE) {
-                    QualifiedNameReferenceNode qualifiedNameReferenceNode =
-                            (QualifiedNameReferenceNode) parameterTypeNode;
-                    String identifier = qualifiedNameReferenceNode.identifier().text();
-                    if (identifier.equals(customTypeName)) {
-                        return requiredParameterNode;
-                    }
+                if (parameterTypeNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE
+                        || parameterTypeNode.kind() == QUALIFIED_NAME_REFERENCE) {
+                    return requiredParameterNode;
                 }
             }
         }
         return null;
+    }
+
+    /**
+     * Reads the actual type name off a parameter resolved by {@link #findCustomTypeParameter}.
+     *
+     * @param requiredParameterNode the resolved parameter node
+     * @return the parameter's declared type name
+     */
+    private String resolveParameterTypeName(RequiredParameterNode requiredParameterNode) {
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (parameterTypeNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
+            return ((SimpleNameReferenceNode) parameterTypeNode).name().toString().trim();
+        }
+        return ((QualifiedNameReferenceNode) parameterTypeNode).identifier().text();
     }
 
     private Optional<String> getDispatcherTypeFromAnnotation(NodeList<AnnotationNode> annotationNodes) {

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
@@ -717,9 +717,6 @@ class BallerinaToAsyncApiGeneratorTest {
 
     @Test
     void testMismatchedFunctionName_stillGeneratesFullSpec() throws IOException {
-        // Regression test for #6601: a remote function's name no longer needs to follow
-        // on<ParameterType> - the parameter's actual declared type drives generation, not a
-        // name-derived guess.
         List<AsyncApiConverterDiagnostic> diagnostics = run(BAL_MISMATCHED_FUNCTION_NAME);
         Assert.assertTrue(diagnostics.isEmpty(),
                 "generator must produce no diagnostics regardless of the remote function's name");

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
@@ -80,6 +80,31 @@ class BallerinaToAsyncApiGeneratorTest {
             + "    }\n"
             + "}\n";
 
+    // Regression fixture for #6601 — function name "onHello" does not follow the on<ParameterType>
+    // convention even though the parameter type is ClientData. Must still generate a full spec.
+    private static final String BAL_MISMATCHED_FUNCTION_NAME =
+            "import ballerina/websocket;\n\n"
+            + "public type ClientData record {\n"
+            + "    string event;\n"
+            + "    string id;\n"
+            + "};\n\n"
+            + "public type User record {\n"
+            + "    string name;\n"
+            + "    string gender;\n"
+            + "};\n\n"
+            + "@websocket:ServiceConfig {dispatcherKey: \"event\"}\n"
+            + "service / on new websocket:Listener(9090) {\n"
+            + "    resource function get .() returns websocket:Service|websocket:UpgradeError {\n"
+            + "        return new WsService();\n"
+            + "    }\n"
+            + "}\n\n"
+            + "service class WsService {\n"
+            + "    *websocket:Service;\n"
+            + "    remote function onHello(ClientData clientData) returns User[] {\n"
+            + "        return [];\n"
+            + "    }\n"
+            + "}\n";
+
     // Three remote functions — produces orders_asyncapi.yaml (service /orders).
     // Type names Order, Cancel, Update match functionName.substring(2) exactly.
     private static final String BAL_THREE_REMOTES =
@@ -638,6 +663,25 @@ class BallerinaToAsyncApiGeneratorTest {
                 "remoteRequestTypeName 'ChatMessage' (onChatMessage.substring(2)) must appear in spec");
         Assert.assertTrue(yaml.contains("sendChatMessage"),
                 "send operation 'sendChatMessage' must appear in spec");
+    }
+
+    @Test
+    void testMismatchedFunctionName_stillGeneratesFullSpec() throws IOException {
+        // Regression test for #6601: a remote function's name no longer needs to follow
+        // on<ParameterType> - the parameter's actual declared type drives generation, not a
+        // name-derived guess.
+        List<AsyncApiConverterDiagnostic> diagnostics = run(BAL_MISMATCHED_FUNCTION_NAME);
+        Assert.assertTrue(diagnostics.isEmpty(),
+                "generator must produce no diagnostics regardless of the remote function's name");
+        String yaml = readFile("service_asyncapi.yaml");
+        Assert.assertTrue(yaml.contains("ClientData"),
+                "ClientData schema/message must appear even though the function is named 'onHello'");
+        Assert.assertTrue(yaml.contains("User"),
+                "User (return type) schema must appear even though the function is named 'onHello'");
+        Assert.assertTrue(yaml.contains("sendClientData"),
+                "send operation must be derived from the parameter's real type, not the function name");
+        Assert.assertFalse(yaml.contains("operations: {}"),
+                "operations must not be empty - a mismatched name must not cause silent skipping");
     }
 
     @Test

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
@@ -105,6 +105,37 @@ class BallerinaToAsyncApiGeneratorTest {
             + "    }\n"
             + "}\n";
 
+    // Exact scenario from the original #6601 issue: parameter/return types referenced via a
+    // *qualified* name from an imported submodule (types:ClientData), not a same-file simple
+    // name. Exercises the QUALIFIED_NAME_REFERENCE branch of resolveParameterTypeName(), which
+    // BAL_MISMATCHED_FUNCTION_NAME above doesn't reach. Paired with TYPES_SUBMODULE_SOURCE,
+    // written into modules/types/types.bal by runWithTypesSubmodule().
+    private static final String BAL_MISMATCHED_FUNCTION_NAME_QUALIFIED_TYPE =
+            "import ballerina/websocket;\n"
+            + "import testorg/asyncspectest.types;\n\n"
+            + "@websocket:ServiceConfig {dispatcherKey: \"event\"}\n"
+            + "service / on new websocket:Listener(9090) {\n"
+            + "    resource function get .() returns websocket:Service|websocket:UpgradeError {\n"
+            + "        return new WsService();\n"
+            + "    }\n"
+            + "}\n\n"
+            + "service class WsService {\n"
+            + "    *websocket:Service;\n"
+            + "    remote function onHello(types:ClientData clientData) returns types:User[] {\n"
+            + "        return [];\n"
+            + "    }\n"
+            + "}\n";
+
+    private static final String TYPES_SUBMODULE_SOURCE =
+            "public type ClientData record {\n"
+            + "    string event;\n"
+            + "    string id;\n"
+            + "};\n\n"
+            + "public type User record {\n"
+            + "    string name;\n"
+            + "    string gender;\n"
+            + "};\n";
+
     // Three remote functions — produces orders_asyncapi.yaml (service /orders).
     // Type names Order, Cancel, Update match functionName.substring(2) exactly.
     private static final String BAL_THREE_REMOTES =
@@ -619,6 +650,18 @@ class BallerinaToAsyncApiGeneratorTest {
                 balFile, outDir, null, needJson, System.out);
     }
 
+    // Writes TYPES_SUBMODULE_SOURCE into modules/types/types.bal (importable as
+    // testorg/asyncspectest.types) alongside the given main source, so tests can exercise a
+    // qualified (cross-module) type reference the way the original #6601 issue's repro did.
+    private List<AsyncApiConverterDiagnostic> runWithTypesSubmodule(String source) throws IOException {
+        Path modulesDir = projectDir.resolve("modules").resolve("types");
+        Files.createDirectories(modulesDir);
+        Files.writeString(modulesDir.resolve("types.bal"), TYPES_SUBMODULE_SOURCE);
+        Path balFile = writeBalSource(source);
+        return BallerinaToAsyncApiGenerator.generateAsyncAPIDefinitionsAllService(
+                balFile, outDir, null, false, System.out);
+    }
+
     private String readFile(String fileName) throws IOException {
         return Files.readString(outDir.resolve(fileName));
     }
@@ -678,6 +721,30 @@ class BallerinaToAsyncApiGeneratorTest {
                 "ClientData schema/message must appear even though the function is named 'onHello'");
         Assert.assertTrue(yaml.contains("User"),
                 "User (return type) schema must appear even though the function is named 'onHello'");
+        Assert.assertTrue(yaml.contains("sendClientData"),
+                "send operation must be derived from the parameter's real type, not the function name");
+        Assert.assertFalse(yaml.contains("operations: {}"),
+                "operations must not be empty - a mismatched name must not cause silent skipping");
+    }
+
+    @Test
+    void testMismatchedFunctionName_qualifiedTypeReference_stillGeneratesFullSpec() throws IOException {
+        // Exact scenario from the original #6601 issue report: parameter/return types
+        // referenced via a qualified name from an imported submodule (types:ClientData,
+        // types:User), not a same-file simple name. testMismatchedFunctionName_
+        // stillGeneratesFullSpec above only exercises the SIMPLE_NAME_REFERENCE branch of
+        // resolveParameterTypeName() - this exercises the QUALIFIED_NAME_REFERENCE branch,
+        // which was left unchanged by the fix and needed its own direct verification.
+        List<AsyncApiConverterDiagnostic> diagnostics =
+                runWithTypesSubmodule(BAL_MISMATCHED_FUNCTION_NAME_QUALIFIED_TYPE);
+        Assert.assertTrue(diagnostics.isEmpty(),
+                "generator must produce no diagnostics regardless of the remote function's name, "
+                        + "even when the parameter type is a qualified reference to an imported module");
+        String yaml = readFile("service_asyncapi.yaml");
+        Assert.assertTrue(yaml.contains("ClientData"),
+                "ClientData schema/message must appear even with a qualified type reference");
+        Assert.assertTrue(yaml.contains("User"),
+                "User (return type) schema must appear even with a qualified type reference");
         Assert.assertTrue(yaml.contains("sendClientData"),
                 "send operation must be derived from the parameter's real type, not the function name");
         Assert.assertFalse(yaml.contains("operations: {}"),


### PR DESCRIPTION
## Purpose
When generating an AsyncAPI spec from a `websocket:Service` class, a `remote` function's parameter and return types are only picked up if the function is named `on<ParameterType>` exactly. Any other name causes the tool to silently generate an incomplete spec - missing schemas, messages, and operations for that function - with no diagnostic or error.

Resolves: https://github.com/ballerina-platform/ballerina-library/issues/6601

## Goals
Generate a complete spec for a remote function regardless of its name, driven entirely by its actual parameter type rather than a name-derived guess.

## Approach
`AsyncApiRemoteMapper.handleRemoteFunctions()` previously derived an expected type name by stripping "on" off the function name, then searched the function's parameters for one matching that guess - silently skipping the function entirely if nothing matched. Replaced this with a direct lookup: `findCustomTypeParameter()` finds the function's actual custom-type parameter first, and `resolveParameterTypeName()` reads its real declared type name off it. The function's name no longer factors into type resolution. The existing annotation-based dispatcher-type override is untouched, since that's an intentional override rather than the broken fallback path.

## User stories
As a developer writing a WebSocket service class, I want my remote functions' names to reflect what they do (e.g. `onNewMessage`) rather than being forced to match my parameter's type name, so that the generated spec is complete regardless of how I name my functions.

## Release note
Fixed AsyncAPI spec generation for WebSocket services silently omitting schemas, messages, and operations for remote functions whose name didn't follow the `on<ParameterType>` convention.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  New regression test `testMismatchedFunctionName_stillGeneratesFullSpec` added, reproducing the original bug (function named `onHello` with a `ClientData` parameter) and asserting a complete spec is generated. No formal coverage percentage tracked for this module.
- Integration tests
  Full `asyncapi-generator` test suite (330/330) passes with no regressions.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
See also the PR for #8713 - both touch `AsyncApiRemoteMapper.java` in the same WS spec-generation subsystem, but are independent fixes with no overlap in changed methods.

## Migrations (if applicable)
N/A

## Test environment
## Test environment
JDK 21 (Temurin 21.0.2), Windows 11, Ballerina distribution 2201.13.0.

