### PR TITLE
Generate outbound connection auth fields from AsyncAPI securitySchemes

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
@@ -112,7 +112,8 @@ public class HttpCodeGenerator {
         String dataTypesContent = new DataTypesGenerator(schemas, webhookAuthConfig, connectionAuthConfig)
                 .generate();
         String serviceTypesContent = new ServiceTypesGenerator(serviceTypes).generate();
-        String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig).generate();
+        String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig, connectionAuthConfig)
+                .generate();
         String serviceName = deriveServiceName(outputPath);
         String dispatcherContent =
                 new DispatcherGenerator(serviceTypes, identifierConfig, webhookAuthConfig, serviceName)

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
@@ -20,6 +20,7 @@ package io.ballerina.asyncapi.generator.http;
 import io.ballerina.asyncapi.core.api.AsyncApiSpec;
 import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.extractor.ConnectionAuthExtractor;
 import io.ballerina.asyncapi.generator.http.extractor.DispatchTestCaseExtractor;
 import io.ballerina.asyncapi.generator.http.extractor.EventIdentifierExtractor;
 import io.ballerina.asyncapi.generator.http.extractor.SchemaExtractor;
@@ -30,6 +31,7 @@ import io.ballerina.asyncapi.generator.http.generator.DispatchTestGenerator;
 import io.ballerina.asyncapi.generator.http.generator.DispatcherGenerator;
 import io.ballerina.asyncapi.generator.http.generator.ListenerGenerator;
 import io.ballerina.asyncapi.generator.http.generator.ServiceTypesGenerator;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.DispatchTestCase;
 import io.ballerina.asyncapi.generator.http.model.EventIdentifierConfig;
 import io.ballerina.asyncapi.generator.http.model.HttpServiceType;
@@ -104,9 +106,11 @@ public class HttpCodeGenerator {
         schemas.putAll(serviceTypeExtractor.getInlineSchemas());
         Optional<WebhookAuthConfig> webhookAuthConfig = new WebhookAuthExtractor(asyncApiSpec).extract();
         validateWebhookDsl(webhookAuthConfig);
+        Optional<ConnectionAuthConfig> connectionAuthConfig = new ConnectionAuthExtractor(asyncApiSpec).extract();
 
         // Generate Ballerina source content
-        String dataTypesContent = new DataTypesGenerator(schemas, webhookAuthConfig).generate();
+        String dataTypesContent = new DataTypesGenerator(schemas, webhookAuthConfig, connectionAuthConfig)
+                .generate();
         String serviceTypesContent = new ServiceTypesGenerator(serviceTypes).generate();
         String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig).generate();
         String serviceName = deriveServiceName(outputPath);

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
@@ -39,11 +39,16 @@ import java.util.stream.Collectors;
  * with no custom syntax of its own: a spec that honestly documents how its own outbound API calls
  * are authenticated already has everything this extractor needs.
  *
- * <p>Only {@code oauth2} (with the {@code authorizationCode} or {@code clientCredentials} flow)
- * and {@code userPassword} scheme types are currently supported. A recognized scheme type in an
- * unsupported shape (e.g. {@code oauth2} declaring only the {@code implicit} flow) fails loudly
- * with a {@link GeneratorException} rather than being silently ignored, since a spec author
- * declaring such a scheme clearly intended it to be used.
+ * <p>Only {@code oauth2} (with the {@code authorizationCode} or {@code clientCredentials} flow),
+ * {@code userPassword}, {@code httpApiKey}, and {@code X509} scheme types are currently supported.
+ * A recognized scheme type in an unsupported shape (e.g. {@code oauth2} declaring only the
+ * {@code implicit} flow, or {@code httpApiKey} missing a required field) fails loudly with a
+ * {@link GeneratorException} rather than being silently ignored, since a spec author declaring
+ * such a scheme clearly intended it to be used.
+ *
+ * <p><b>Note:</b> {@code httpApiKey} (supported) and the generic AsyncAPI {@code apiKey} type
+ * (out of scope, stays silently ignored like any other unrecognized type) are different
+ * {@code type} strings - easy to conflate, but not the same scheme.
  */
 public final class ConnectionAuthExtractor {
 
@@ -63,9 +68,10 @@ public final class ConnectionAuthExtractor {
      * spec author can remove the ones that don't apply to this trigger's outbound calls.
      *
      * @return an {@link Optional} containing the resolved {@link ConnectionAuthConfig} if exactly
-     *         one recognized scheme type ({@code oauth2} or {@code userPassword}) is present;
-     *         {@link Optional#empty()} if no security schemes are declared at all, or only
-     *         scheme types outside this extractor's scope (e.g. {@code apiKey}, {@code http})
+     *         one recognized scheme type ({@code oauth2}, {@code userPassword}, {@code httpApiKey},
+     *         or {@code X509}) is present; {@link Optional#empty()} if no security schemes are
+     *         declared at all, or only scheme types outside this extractor's scope (e.g.
+     *         {@code apiKey}, {@code http})
      * @throws GeneratorException if more than one recognized scheme is declared, or if the single
      *                            recognized scheme is present but in an unsupported shape
      *                            (unsupported {@code oauth2} flow, or a required URL missing)
@@ -83,7 +89,9 @@ public final class ConnectionAuthExtractor {
         List<Map.Entry<String, AsyncApiSecurityScheme>> candidates = securitySchemes.entrySet().stream()
                 .filter(entry -> entry.getValue() != null && entry.getValue().type() != null)
                 .filter(entry -> ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(entry.getValue().type())
-                        || ConnectionAuthConfig.TYPE_OAUTH2.equals(entry.getValue().type()))
+                        || ConnectionAuthConfig.TYPE_OAUTH2.equals(entry.getValue().type())
+                        || ConnectionAuthConfig.TYPE_HTTP_API_KEY.equals(entry.getValue().type())
+                        || ConnectionAuthConfig.TYPE_X509.equals(entry.getValue().type()))
                 .toList();
         if (candidates.isEmpty()) {
             return Optional.empty();
@@ -102,7 +110,35 @@ public final class ConnectionAuthExtractor {
             return Optional.of(new ConnectionAuthConfig(
                     ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null));
         }
+        if (ConnectionAuthConfig.TYPE_X509.equals(scheme.type())) {
+            // AsyncAPI intentionally carries no certificate material in the spec itself (same as
+            // OpenAPI) - the scheme just declares that mutual TLS is required, nothing more to
+            // extract.
+            return Optional.of(new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_X509, null, null, null));
+        }
+        if (ConnectionAuthConfig.TYPE_HTTP_API_KEY.equals(scheme.type())) {
+            return Optional.of(extractHttpApiKey(scheme));
+        }
         return Optional.of(extractOAuth2(scheme));
+    }
+
+    private ConnectionAuthConfig extractHttpApiKey(AsyncApiSecurityScheme scheme) throws GeneratorException {
+        String name = scheme.name();
+        if (name == null || name.isBlank()) {
+            throw new GeneratorException(
+                    "httpApiKey security scheme requires a 'name' - the header/query/cookie "
+                            + "parameter name the API key is sent as");
+        }
+        String in = scheme.in();
+        if (!ConnectionAuthConfig.API_KEY_IN_HEADER.equals(in)
+                && !ConnectionAuthConfig.API_KEY_IN_QUERY.equals(in)
+                && !ConnectionAuthConfig.API_KEY_IN_COOKIE.equals(in)) {
+            throw new GeneratorException(
+                    "httpApiKey security scheme requires 'in' to be one of 'header', 'query', "
+                            + "or 'cookie', but was: " + in);
+        }
+        return new ConnectionAuthConfig(
+                ConnectionAuthConfig.TYPE_HTTP_API_KEY, null, null, null, name, in);
     }
 
     private ConnectionAuthConfig extractOAuth2(AsyncApiSecurityScheme scheme) throws GeneratorException {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
@@ -150,6 +150,15 @@ public final class ConnectionAuthExtractor {
         }
 
         AsyncApiOAuthFlow authorizationCode = flows.authorizationCode();
+        AsyncApiOAuthFlow clientCredentials = flows.clientCredentials();
+        if (authorizationCode != null && clientCredentials != null) {
+            throw new GeneratorException(
+                    "oauth2 security scheme declares both authorizationCode and clientCredentials flows "
+                            + "- only one is supported per spec, since it's ambiguous which one the "
+                            + "generated trigger should use for its outbound calls. Remove the flow "
+                            + "that doesn't apply.");
+        }
+
         if (authorizationCode != null) {
             if (authorizationCode.refreshUrl() == null) {
                 throw new GeneratorException(
@@ -161,7 +170,6 @@ public final class ConnectionAuthExtractor {
                     authorizationCode.refreshUrl().toString());
         }
 
-        AsyncApiOAuthFlow clientCredentials = flows.clientCredentials();
         if (clientCredentials != null) {
             if (clientCredentials.tokenUrl() == null) {
                 throw new GeneratorException(

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.asyncapi.generator.http.extractor;
+
+import io.ballerina.asyncapi.core.api.AsyncApiSpec;
+import io.ballerina.asyncapi.core.model.component.AsyncApiComponent;
+import io.ballerina.asyncapi.core.model.security.AsyncApiOAuthFlow;
+import io.ballerina.asyncapi.core.model.security.AsyncApiOAuthFlows;
+import io.ballerina.asyncapi.core.model.security.AsyncApiSecurityScheme;
+import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Extracts outbound (client-side) API authentication configuration from the standard
+ * {@code components.securitySchemes} section of an AsyncAPI document.
+ *
+ * <p>Distinct from {@link WebhookAuthExtractor}, which reads the custom {@code x-ballerina-auth}
+ * extension for inbound webhook verification. This extractor reads a standard AsyncAPI construct
+ * with no custom syntax of its own: a spec that honestly documents how its own outbound API calls
+ * are authenticated already has everything this extractor needs.
+ *
+ * <p>Only {@code oauth2} (with the {@code authorizationCode} or {@code clientCredentials} flow)
+ * and {@code userPassword} scheme types are currently supported. A recognized scheme type in an
+ * unsupported shape (e.g. {@code oauth2} declaring only the {@code implicit} flow) fails loudly
+ * with a {@link GeneratorException} rather than being silently ignored, since a spec author
+ * declaring such a scheme clearly intended it to be used.
+ */
+public final class ConnectionAuthExtractor {
+
+    private final AsyncApiSpec asyncApiSpec;
+
+    public ConnectionAuthExtractor(AsyncApiSpec asyncApiSpec) {
+        this.asyncApiSpec = asyncApiSpec;
+    }
+
+    /**
+     * Extracts the outbound auth configuration from the spec's {@code components.securitySchemes}.
+     *
+     * @return an {@link Optional} containing the resolved {@link ConnectionAuthConfig} if a
+     *         recognized scheme type ({@code oauth2} or {@code userPassword}) is present;
+     *         {@link Optional#empty()} if no security schemes are declared at all, or only
+     *         scheme types outside this extractor's scope (e.g. {@code apiKey}, {@code http})
+     * @throws GeneratorException if a recognized scheme type is present but in an unsupported
+     *                            shape (unsupported {@code oauth2} flow, or a required URL missing)
+     */
+    public Optional<ConnectionAuthConfig> extract() throws GeneratorException {
+        Optional<AsyncApiComponent> components = asyncApiSpec.getAsyncApiComponents();
+        if (components.isEmpty()) {
+            return Optional.empty();
+        }
+        Map<String, AsyncApiSecurityScheme> securitySchemes = components.get().securitySchemes();
+        if (securitySchemes == null || securitySchemes.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (AsyncApiSecurityScheme scheme : securitySchemes.values()) {
+            if (scheme == null || scheme.type() == null) {
+                continue;
+            }
+            if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(scheme.type())) {
+                return Optional.of(new ConnectionAuthConfig(
+                        ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null));
+            }
+            if (ConnectionAuthConfig.TYPE_OAUTH2.equals(scheme.type())) {
+                return Optional.of(extractOAuth2(scheme));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private ConnectionAuthConfig extractOAuth2(AsyncApiSecurityScheme scheme) throws GeneratorException {
+        AsyncApiOAuthFlows flows = scheme.flows();
+        if (flows == null) {
+            throw new GeneratorException(
+                    "oauth2 security scheme requires a 'flows' object with a supported flow "
+                            + "(authorizationCode or clientCredentials)");
+        }
+
+        AsyncApiOAuthFlow authorizationCode = flows.authorizationCode();
+        if (authorizationCode != null) {
+            if (authorizationCode.refreshUrl() == null) {
+                throw new GeneratorException(
+                        "oauth2 authorizationCode flow requires a refreshUrl - the generated trigger "
+                                + "uses it to refresh access tokens at runtime");
+            }
+            return new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2,
+                    ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE, null,
+                    authorizationCode.refreshUrl().toString());
+        }
+
+        AsyncApiOAuthFlow clientCredentials = flows.clientCredentials();
+        if (clientCredentials != null) {
+            if (clientCredentials.tokenUrl() == null) {
+                throw new GeneratorException(
+                        "oauth2 clientCredentials flow requires a tokenUrl");
+            }
+            return new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2,
+                    ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS,
+                    clientCredentials.tokenUrl().toString(), null);
+        }
+
+        throw new GeneratorException(
+                "Unsupported oauth2 flow - only authorizationCode and clientCredentials are "
+                        + "currently supported for generated trigger outbound authentication");
+    }
+}

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractor.java
@@ -25,8 +25,10 @@ import io.ballerina.asyncapi.core.model.security.AsyncApiSecurityScheme;
 import io.ballerina.asyncapi.generator.GeneratorException;
 import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Extracts outbound (client-side) API authentication configuration from the standard
@@ -54,12 +56,19 @@ public final class ConnectionAuthExtractor {
     /**
      * Extracts the outbound auth configuration from the spec's {@code components.securitySchemes}.
      *
-     * @return an {@link Optional} containing the resolved {@link ConnectionAuthConfig} if a
-     *         recognized scheme type ({@code oauth2} or {@code userPassword}) is present;
+     * <p>Exactly one {@code oauth2}/{@code userPassword} entry is expected. If more than one is
+     * declared, which one the generated trigger should actually use is genuinely ambiguous -
+     * rather than silently picking the first one encountered and leaving the rest to be
+     * discovered missing at runtime, this fails loudly and names the conflicting entries so the
+     * spec author can remove the ones that don't apply to this trigger's outbound calls.
+     *
+     * @return an {@link Optional} containing the resolved {@link ConnectionAuthConfig} if exactly
+     *         one recognized scheme type ({@code oauth2} or {@code userPassword}) is present;
      *         {@link Optional#empty()} if no security schemes are declared at all, or only
      *         scheme types outside this extractor's scope (e.g. {@code apiKey}, {@code http})
-     * @throws GeneratorException if a recognized scheme type is present but in an unsupported
-     *                            shape (unsupported {@code oauth2} flow, or a required URL missing)
+     * @throws GeneratorException if more than one recognized scheme is declared, or if the single
+     *                            recognized scheme is present but in an unsupported shape
+     *                            (unsupported {@code oauth2} flow, or a required URL missing)
      */
     public Optional<ConnectionAuthConfig> extract() throws GeneratorException {
         Optional<AsyncApiComponent> components = asyncApiSpec.getAsyncApiComponents();
@@ -71,19 +80,29 @@ public final class ConnectionAuthExtractor {
             return Optional.empty();
         }
 
-        for (AsyncApiSecurityScheme scheme : securitySchemes.values()) {
-            if (scheme == null || scheme.type() == null) {
-                continue;
-            }
-            if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(scheme.type())) {
-                return Optional.of(new ConnectionAuthConfig(
-                        ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null));
-            }
-            if (ConnectionAuthConfig.TYPE_OAUTH2.equals(scheme.type())) {
-                return Optional.of(extractOAuth2(scheme));
-            }
+        List<Map.Entry<String, AsyncApiSecurityScheme>> candidates = securitySchemes.entrySet().stream()
+                .filter(entry -> entry.getValue() != null && entry.getValue().type() != null)
+                .filter(entry -> ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(entry.getValue().type())
+                        || ConnectionAuthConfig.TYPE_OAUTH2.equals(entry.getValue().type()))
+                .toList();
+        if (candidates.isEmpty()) {
+            return Optional.empty();
         }
-        return Optional.empty();
+        if (candidates.size() > 1) {
+            String names = candidates.stream().map(Map.Entry::getKey).collect(Collectors.joining(", "));
+            throw new GeneratorException(
+                    "Multiple outbound auth schemes declared under components.securitySchemes (" + names + ") "
+                            + "- only one is supported per spec, since it's ambiguous which one the generated "
+                            + "trigger should use. Remove the entries that don't apply to this trigger's "
+                            + "outbound calls.");
+        }
+
+        AsyncApiSecurityScheme scheme = candidates.get(0).getValue();
+        if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(scheme.type())) {
+            return Optional.of(new ConnectionAuthConfig(
+                    ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null));
+        }
+        return Optional.of(extractOAuth2(scheme));
     }
 
     private ConnectionAuthConfig extractOAuth2(AsyncApiSecurityScheme scheme) throws GeneratorException {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
@@ -19,6 +19,7 @@ package io.ballerina.asyncapi.generator.http.generator;
 
 import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import io.ballerina.asyncapi.generator.http.node.GenerateHttpImportNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateListenerConfigNode;
@@ -55,17 +56,23 @@ public class DataTypesGenerator {
 
     private final Map<String, AsyncApiSchema> schemas;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
+    private final Optional<ConnectionAuthConfig> connectionAuthConfig;
 
     /**
      * Creates a generator for the given schema map.
      *
-     * @param schemas           map of schema name to schema object from the AsyncAPI components
-     * @param webhookAuthConfig the optional webhook authentication configuration, whose
-     *                          {@code $config('name')} references become extra listener config fields
+     * @param schemas              map of schema name to schema object from the AsyncAPI components
+     * @param webhookAuthConfig    the optional webhook authentication configuration, whose
+     *                             {@code $config('name')} references become extra listener config fields
+     * @param connectionAuthConfig the optional outbound (client-side) API authentication configuration,
+     *                             whose type/flow determines any additional listener config fields
+     *                             (e.g. {@code clientId}/{@code clientSecret}/{@code refreshToken})
      */
-    public DataTypesGenerator(Map<String, AsyncApiSchema> schemas, Optional<WebhookAuthConfig> webhookAuthConfig) {
+    public DataTypesGenerator(Map<String, AsyncApiSchema> schemas, Optional<WebhookAuthConfig> webhookAuthConfig,
+            Optional<ConnectionAuthConfig> connectionAuthConfig) {
         this.schemas = schemas;
         this.webhookAuthConfig = webhookAuthConfig;
+        this.connectionAuthConfig = connectionAuthConfig;
     }
 
     /**
@@ -80,7 +87,7 @@ public class DataTypesGenerator {
                 .orElseGet(List::of);
         List<ModuleMemberDeclarationNode> typeNodes = new ArrayList<>();
         typeNodes.add(GenerateListenerConfigNode.generateDefaultSecretConst());
-        typeNodes.add(GenerateListenerConfigNode.generate(extraConfigFields));
+        typeNodes.add(GenerateListenerConfigNode.generate(extraConfigFields, connectionAuthConfig));
         List<TypeDescriptorNode> typeDescriptors = new ArrayList<>();
 
         for (Map.Entry<String, AsyncApiSchema> entry : schemas.entrySet()) {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
@@ -21,6 +21,7 @@ import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
 import io.ballerina.asyncapi.generator.GeneratorException;
 import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
+import io.ballerina.asyncapi.generator.http.node.GenerateCryptoImportNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateHttpImportNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateListenerConfigNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateModuleMemberDeclarationNode;
@@ -103,13 +104,20 @@ public class DataTypesGenerator {
         Generator unionGen = new GenerateUnionDescriptorNode(typeDescriptors, GENERIC_DATA_TYPE);
         typeNodes.add(unionGen.generate());
 
-        ImportDeclarationNode importNode = GenerateHttpImportNode.generate();
+        List<ImportDeclarationNode> imports = new ArrayList<>();
+        imports.add(GenerateHttpImportNode.generate());
+        if (connectionAuthConfig.isPresent()
+                && ConnectionAuthConfig.TYPE_X509.equals(connectionAuthConfig.get().type())) {
+            // X509's cert/keyConfig fields are crypto:TrustStore|string and crypto:KeyStore|http:CertKey -
+            // only pull in the crypto import when a scheme actually needs it.
+            imports.add(GenerateCryptoImportNode.generate());
+        }
 
         TextDocument textDocument = TextDocuments.from("");
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         ModulePartNode oldRoot = syntaxTree.rootNode();
         ModulePartNode newRoot = oldRoot.modify()
-                .withImports(createNodeList(importNode))
+                .withImports(createNodeList(imports))
                 .withMembers(oldRoot.members().addAll(typeNodes))
                 .apply();
         SyntaxTree modifiedTree = syntaxTree.replaceNode(oldRoot, newRoot);

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ListenerGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ListenerGenerator.java
@@ -18,6 +18,7 @@
 package io.ballerina.asyncapi.generator.http.generator;
 
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.HttpServiceType;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import io.ballerina.asyncapi.generator.http.node.GenerateCloudImportNode;
@@ -48,17 +49,22 @@ public class ListenerGenerator {
 
     private final List<HttpServiceType> serviceTypes;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
+    private final Optional<ConnectionAuthConfig> connectionAuthConfig;
 
     /**
-     * Creates a generator for the given list of service types and optional webhook auth configuration.
+     * Creates a generator for the given list of service types and optional webhook/connection
+     * auth configuration.
      *
-     * @param serviceTypes      the list of HTTP service type definitions to generate
-     * @param webhookAuthConfig the optional webhook authentication configuration
+     * @param serviceTypes         the list of HTTP service type definitions to generate
+     * @param webhookAuthConfig    the optional webhook authentication configuration
+     * @param connectionAuthConfig the optional outbound (client-side) API authentication
+     *                             configuration
      */
     public ListenerGenerator(List<HttpServiceType> serviceTypes,
-            Optional<WebhookAuthConfig> webhookAuthConfig) {
+            Optional<WebhookAuthConfig> webhookAuthConfig, Optional<ConnectionAuthConfig> connectionAuthConfig) {
         this.serviceTypes = serviceTypes;
         this.webhookAuthConfig = webhookAuthConfig;
+        this.connectionAuthConfig = connectionAuthConfig;
     }
 
     /**
@@ -72,7 +78,8 @@ public class ListenerGenerator {
             throw new GeneratorException("No service types defined; cannot generate listener.bal");
         }
 
-        ClassDefinitionNode classNode = new GenerateListenerClassNode(serviceTypes, webhookAuthConfig).generate();
+        ClassDefinitionNode classNode = new GenerateListenerClassNode(serviceTypes, webhookAuthConfig,
+                connectionAuthConfig).generate();
         ImportDeclarationNode httpImport = GenerateHttpImportNode.generate();
         ImportDeclarationNode cloudImport = GenerateCloudImportNode.generate();
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.asyncapi.generator.http.model;
+
+/**
+ * Holds the resolved outbound (client-side) API authentication configuration, extracted from a
+ * recognized entry in the AsyncAPI document's standard {@code components.securitySchemes} section.
+ *
+ * <p>Distinct from {@link WebhookAuthConfig}: this describes credentials the generated trigger
+ * needs to call the provider's own API (e.g. to register a webhook subscription or fetch a
+ * changed resource), not credentials used to verify an inbound webhook request.
+ *
+ * @param type       the security scheme type: {@code "oauth2"} or {@code "userPassword"}
+ * @param flow       for {@code type == "oauth2"}, the OAuth flow: {@code "authorizationCode"} or
+ *                   {@code "clientCredentials"}; {@code null} for {@code "userPassword"}
+ * @param tokenUrl   the resolved token endpoint URL for the {@code clientCredentials} flow;
+ *                   {@code null} otherwise. Generated as a constant, not a user-configurable field,
+ *                   since it is fixed by the provider rather than varying per deployment.
+ * @param refreshUrl the resolved refresh endpoint URL for the {@code authorizationCode} flow;
+ *                   {@code null} otherwise. Generated as a constant for the same reason.
+ */
+public record ConnectionAuthConfig(
+        String type,
+        String flow,
+        String tokenUrl,
+        String refreshUrl
+) {
+
+    public static final String TYPE_OAUTH2 = "oauth2";
+    public static final String TYPE_USER_PASSWORD = "userPassword";
+    public static final String FLOW_AUTHORIZATION_CODE = "authorizationCode";
+    public static final String FLOW_CLIENT_CREDENTIALS = "clientCredentials";
+}

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
@@ -29,10 +29,13 @@ package io.ballerina.asyncapi.generator.http.model;
  * @param flow       for {@code type == "oauth2"}, the OAuth flow: {@code "authorizationCode"} or
  *                   {@code "clientCredentials"}; {@code null} for {@code "userPassword"}
  * @param tokenUrl   the resolved token endpoint URL for the {@code clientCredentials} flow;
- *                   {@code null} otherwise. Generated as a constant, not a user-configurable field,
- *                   since it is fixed by the provider rather than varying per deployment.
+ *                   {@code null} otherwise. Generated as a {@code ListenerConfig} field defaulted
+ *                   to this value (not hardcoded), since a spec cannot distinguish a URL that's
+ *                   fixed by the provider from one that varies per deployment (e.g. a per-tenant
+ *                   identity provider) - the default covers the common case while staying
+ *                   overridable for the other.
  * @param refreshUrl the resolved refresh endpoint URL for the {@code authorizationCode} flow;
- *                   {@code null} otherwise. Generated as a constant for the same reason.
+ *                   {@code null} otherwise. Generated the same way, for the same reason.
  */
 public record ConnectionAuthConfig(
         String type,

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/ConnectionAuthConfig.java
@@ -25,9 +25,10 @@ package io.ballerina.asyncapi.generator.http.model;
  * needs to call the provider's own API (e.g. to register a webhook subscription or fetch a
  * changed resource), not credentials used to verify an inbound webhook request.
  *
- * @param type       the security scheme type: {@code "oauth2"} or {@code "userPassword"}
+ * @param type       the security scheme type: {@code "oauth2"}, {@code "userPassword"},
+ *                   {@code "httpApiKey"}, or {@code "X509"}
  * @param flow       for {@code type == "oauth2"}, the OAuth flow: {@code "authorizationCode"} or
- *                   {@code "clientCredentials"}; {@code null} for {@code "userPassword"}
+ *                   {@code "clientCredentials"}; {@code null} for every other type
  * @param tokenUrl   the resolved token endpoint URL for the {@code clientCredentials} flow;
  *                   {@code null} otherwise. Generated as a {@code ListenerConfig} field defaulted
  *                   to this value (not hardcoded), since a spec cannot distinguish a URL that's
@@ -36,16 +37,42 @@ package io.ballerina.asyncapi.generator.http.model;
  *                   overridable for the other.
  * @param refreshUrl the resolved refresh endpoint URL for the {@code authorizationCode} flow;
  *                   {@code null} otherwise. Generated the same way, for the same reason.
+ * @param apiKeyName for {@code type == "httpApiKey"}, the header/query/cookie parameter name the
+ *                   API key is sent as (the spec's {@code name}); {@code null} otherwise.
+ * @param apiKeyIn   for {@code type == "httpApiKey"}, where the key is sent - one of
+ *                   {@code "header"}, {@code "query"}, {@code "cookie"} (the spec's {@code in});
+ *                   {@code null} otherwise.
  */
 public record ConnectionAuthConfig(
         String type,
         String flow,
         String tokenUrl,
-        String refreshUrl
+        String refreshUrl,
+        String apiKeyName,
+        String apiKeyIn
 ) {
 
     public static final String TYPE_OAUTH2 = "oauth2";
     public static final String TYPE_USER_PASSWORD = "userPassword";
+    public static final String TYPE_HTTP_API_KEY = "httpApiKey";
+    public static final String TYPE_X509 = "X509";
     public static final String FLOW_AUTHORIZATION_CODE = "authorizationCode";
     public static final String FLOW_CLIENT_CREDENTIALS = "clientCredentials";
+    public static final String API_KEY_IN_HEADER = "header";
+    public static final String API_KEY_IN_QUERY = "query";
+    public static final String API_KEY_IN_COOKIE = "cookie";
+
+    /**
+     * Convenience constructor for scheme types with no API-key location info
+     * ({@code oauth2}, {@code userPassword}), defaulting {@code apiKeyName}/{@code apiKeyIn} to
+     * {@code null}.
+     *
+     * @param type       the security scheme type
+     * @param flow       the OAuth flow, or {@code null}
+     * @param tokenUrl   the resolved token endpoint URL, or {@code null}
+     * @param refreshUrl the resolved refresh endpoint URL, or {@code null}
+     */
+    public ConnectionAuthConfig(String type, String flow, String tokenUrl, String refreshUrl) {
+        this(type, flow, tokenUrl, refreshUrl, null, null);
+    }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
@@ -19,6 +19,7 @@ package io.ballerina.asyncapi.generator.http.node;
 
 import io.ballerina.asyncapi.generator.GeneratorException;
 import io.ballerina.asyncapi.generator.http.generator.ServiceTypesGenerator;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.HttpServiceType;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
@@ -100,17 +101,25 @@ public class GenerateListenerClassNode implements Generator {
 
     private final List<HttpServiceType> serviceTypes;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
+    private final Optional<ConnectionAuthConfig> connectionAuthConfig;
 
     /**
      * Creates a generator for the {@code Listener} class.
      *
-     * @param serviceTypes      the list of HTTP service type definitions
-     * @param webhookAuthConfig the optional webhook authentication configuration
+     * @param serviceTypes         the list of HTTP service type definitions
+     * @param webhookAuthConfig    the optional webhook authentication configuration
+     * @param connectionAuthConfig the optional outbound (client-side) API authentication
+     *                             configuration - when present, {@code listenerConfig} is
+     *                             generated as a required constructor parameter instead of a
+     *                             defaultable one, since the generated {@code ListenerConfig}
+     *                             then has its own required fields (e.g. a password or client
+     *                             secret) with no safe default value to fall back on
      */
     public GenerateListenerClassNode(List<HttpServiceType> serviceTypes,
-            Optional<WebhookAuthConfig> webhookAuthConfig) {
+            Optional<WebhookAuthConfig> webhookAuthConfig, Optional<ConnectionAuthConfig> connectionAuthConfig) {
         this.serviceTypes = serviceTypes;
         this.webhookAuthConfig = webhookAuthConfig;
+        this.connectionAuthConfig = connectionAuthConfig;
     }
 
     @Override
@@ -195,18 +204,32 @@ public class GenerateListenerClassNode implements Generator {
                         createIdentifierToken("Expose")),
                 null);
 
+        // Connection auth (when present) always contributes at least one required field with no
+        // safe default (a password, client secret, API key value, or certificate) - {webhookSecret:
+        // DEFAULT_SECRET} alone would then be missing those required fields, which Ballerina
+        // rejects outright. So listenerConfig can only stay defaultable when there's no connection
+        // auth to account for; otherwise it must be a required parameter, forcing the caller to
+        // supply real credentials rather than accepting an incomplete or fabricated default.
+        Node listenerConfigParam = connectionAuthConfig.isPresent()
+                ? createRequiredParameterNode(
+                        createEmptyNodeList(),
+                        createSimpleNameReferenceNode(
+                                createIdentifierToken(GenerateListenerConfigNode.LISTENER_CONFIG_TYPE)),
+                        createIdentifierToken("listenerConfig"))
+                : createDefaultableParameterNode(
+                        createEmptyNodeList(),
+                        createSimpleNameReferenceNode(
+                                createIdentifierToken(GenerateListenerConfigNode.LISTENER_CONFIG_TYPE)),
+                        createIdentifierToken("listenerConfig"),
+                        createToken(EQUAL_TOKEN),
+                        NodeParser.parseExpression(String.format("{%s: %s}",
+                                GenerateListenerConfigNode.WEBHOOK_SECRET_FIELD,
+                                GenerateListenerConfigNode.DEFAULT_SECRET_CONST)));
+
         FunctionSignatureNode signature = createFunctionSignatureNode(
                 createToken(OPEN_PAREN_TOKEN),
                 createSeparatedNodeList(
-                        createDefaultableParameterNode(
-                                createEmptyNodeList(),
-                                createSimpleNameReferenceNode(
-                                        createIdentifierToken(GenerateListenerConfigNode.LISTENER_CONFIG_TYPE)),
-                                createIdentifierToken("listenerConfig"),
-                                createToken(EQUAL_TOKEN),
-                                NodeParser.parseExpression(String.format("{%s: %s}",
-                                        GenerateListenerConfigNode.WEBHOOK_SECRET_FIELD,
-                                        GenerateListenerConfigNode.DEFAULT_SECRET_CONST))),
+                        listenerConfigParam,
                         createToken(COMMA_TOKEN),
                         createDefaultableParameterNode(
                                 createNodeList(cloudExposeAnnotation),

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
@@ -271,9 +271,19 @@ public class GenerateListenerConfigNode {
                 createIdentifierToken(fieldName),
                 createToken(EQUAL_TOKEN),
                 createBasicLiteralNode(STRING_LITERAL,
-                        createLiteralValueToken(STRING_LITERAL_TOKEN, "\"" + url + "\"",
+                        createLiteralValueToken(STRING_LITERAL_TOKEN, "\"" + escapeStringLiteral(url) + "\"",
                                 createEmptyMinutiaeList(), createEmptyMinutiaeList())),
                 createToken(SEMICOLON_TOKEN));
+    }
+
+    /**
+     * Escapes {@code \} and {@code "} so a spec-derived value can be embedded in a generated
+     * Ballerina string literal without prematurely closing it or altering the intended text -
+     * e.g. a {@code tokenUrl} containing a literal {@code "} would otherwise produce malformed
+     * generated source.
+     */
+    private static String escapeStringLiteral(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     /**

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
@@ -19,13 +19,13 @@ package io.ballerina.asyncapi.generator.http.node;
 
 import io.ballerina.asyncapi.generator.GeneratorException;
 import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
-import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -38,27 +38,28 @@ import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyN
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createLiteralValueToken;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createNodeList;
-import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createSeparatedNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createToken;
-import static io.ballerina.compiler.syntax.tree.NodeFactory.createAnnotationNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createBasicLiteralNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createBuiltinSimpleNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createConstantDeclarationNode;
-import static io.ballerina.compiler.syntax.tree.NodeFactory.createMappingConstructorExpressionNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationLineNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMetadataNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createQualifiedNameReferenceNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordFieldNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordFieldWithDefaultValueNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
-import static io.ballerina.compiler.syntax.tree.NodeFactory.createSpecificFieldNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createTypeDefinitionNode;
-import static io.ballerina.compiler.syntax.tree.SyntaxKind.AT_TOKEN;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createUnionTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.CLOSE_BRACE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.COLON_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.CONST_KEYWORD;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.DOCUMENTATION_DESCRIPTION;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.EQUAL_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.HASH_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.PIPE_TOKEN;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.PUBLIC_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.RECORD_KEYWORD;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
@@ -105,7 +106,7 @@ public class GenerateListenerConfigNode {
             Optional<ConnectionAuthConfig> connectionAuthConfig) throws GeneratorException {
         List<Node> recordFields = new ArrayList<>();
         recordFields.add(createRecordFieldWithDefaultValueNode(
-                buildDisplayMetadata("Webhook Secret"),
+                buildFieldDocumentation("Webhook Secret"),
                 null,
                 createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
                 createIdentifierToken(WEBHOOK_SECRET_FIELD),
@@ -173,6 +174,12 @@ public class GenerateListenerConfigNode {
         if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(config.type())) {
             return List.of("username", "password");
         }
+        if (ConnectionAuthConfig.TYPE_HTTP_API_KEY.equals(config.type())) {
+            return List.of("apiKeyValue");
+        }
+        if (ConnectionAuthConfig.TYPE_X509.equals(config.type())) {
+            return List.of("cert", "keyConfig");
+        }
         if (ConnectionAuthConfig.TYPE_OAUTH2.equals(config.type())) {
             if (ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE.equals(config.flow())) {
                 return List.of("clientId", "clientSecret", "refreshUrl", "refreshToken");
@@ -201,21 +208,53 @@ public class GenerateListenerConfigNode {
                 fields.add(createUrlFieldWithDefault(fieldName, config.refreshUrl()));
             } else if ("tokenUrl".equals(fieldName)) {
                 fields.add(createUrlFieldWithDefault(fieldName, config.tokenUrl()));
+            } else if ("apiKeyValue".equals(fieldName)) {
+                String description = "API key sent as the '" + config.apiKeyName() + "' HTTP " + config.apiKeyIn();
+                fields.add(createRequiredStringField(fieldName, description));
+            } else if ("cert".equals(fieldName)) {
+                fields.add(createRequiredUnionField(fieldName, "Client certificate for mutual TLS",
+                        qualifiedType(GenerateCryptoImportNode.CRYPTO_MODULE, "TrustStore"),
+                        createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string"))));
+            } else if ("keyConfig".equals(fieldName)) {
+                fields.add(createRequiredUnionField(fieldName, "Client private key for mutual TLS",
+                        qualifiedType(GenerateCryptoImportNode.CRYPTO_MODULE, "KeyStore"),
+                        qualifiedType(GenerateHttpImportNode.HTTP_MODULE, "CertKey")));
             } else {
-                fields.add(createRequiredStringField(fieldName));
+                fields.add(createRequiredStringField(fieldName, toDisplayLabel(fieldName)));
             }
         }
         return fields;
     }
 
-    private static Node createRequiredStringField(String fieldName) {
+    private static Node createRequiredStringField(String fieldName, String description) {
         return createRecordFieldNode(
-                buildDisplayMetadata(toDisplayLabel(fieldName)),
+                buildFieldDocumentation(description),
                 null,
                 createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
                 createIdentifierToken(fieldName),
                 null,
                 createToken(SEMICOLON_TOKEN));
+    }
+
+    /**
+     * Builds a required record field with a union type descriptor (e.g.
+     * {@code crypto:TrustStore|string cert;}), for scheme shapes - currently only {@code X509} -
+     * whose fields aren't a single simple type.
+     */
+    private static Node createRequiredUnionField(String fieldName, String description, TypeDescriptorNode leftType,
+            TypeDescriptorNode rightType) {
+        return createRecordFieldNode(
+                buildFieldDocumentation(description),
+                null,
+                createUnionTypeDescriptorNode(leftType, createToken(PIPE_TOKEN), rightType),
+                createIdentifierToken(fieldName),
+                null,
+                createToken(SEMICOLON_TOKEN));
+    }
+
+    private static TypeDescriptorNode qualifiedType(String module, String typeName) {
+        return createQualifiedNameReferenceNode(
+                createIdentifierToken(module), createToken(COLON_TOKEN), createIdentifierToken(typeName));
     }
 
     /**
@@ -226,7 +265,7 @@ public class GenerateListenerConfigNode {
      */
     private static Node createUrlFieldWithDefault(String fieldName, String url) {
         return createRecordFieldWithDefaultValueNode(
-                buildDisplayMetadata(toDisplayLabel(fieldName)),
+                buildFieldDocumentation(toDisplayLabel(fieldName)),
                 null,
                 createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
                 createIdentifierToken(fieldName),
@@ -276,22 +315,18 @@ public class GenerateListenerConfigNode {
                 createToken(SEMICOLON_TOKEN));
     }
 
-    private static MetadataNode buildDisplayMetadata(String label) {
-        AnnotationNode annotation = createAnnotationNode(
-                createToken(AT_TOKEN),
-                createSimpleNameReferenceNode(createIdentifierToken("display")),
-                createMappingConstructorExpressionNode(
-                        createToken(OPEN_BRACE_TOKEN),
-                        createSeparatedNodeList(
-                                createSpecificFieldNode(
-                                        null,
-                                        createIdentifierToken("label"),
-                                        createToken(COLON_TOKEN),
-                                        createBasicLiteralNode(STRING_LITERAL,
-                                                createLiteralValueToken(STRING_LITERAL_TOKEN,
-                                                        "\"" + label + "\"",
-                                                        createEmptyMinutiaeList(), createEmptyMinutiaeList())))),
-                        createToken(CLOSE_BRACE_TOKEN)));
-        return createMetadataNode(null, createNodeList(annotation));
+    /**
+     * Builds a {@code #} Ballerina doc comment (a {@link MarkdownDocumentationNode}-based
+     * {@link MetadataNode}) for a generated field, e.g. {@code # Client Secret}. Used instead of
+     * a {@code @display} annotation for every field this generator emits, per review decision
+     * (doc comments describe generated {@code ListenerConfig} fields, not {@code @display}).
+     */
+    private static MetadataNode buildFieldDocumentation(String description) {
+        List<Node> docLines = new ArrayList<>();
+        for (String line : description.split("\n")) {
+            docLines.add(createMarkdownDocumentationLineNode(DOCUMENTATION_DESCRIPTION,
+                    createToken(HASH_TOKEN), createNodeList(createIdentifierToken(line))));
+        }
+        return createMetadataNode(createMarkdownDocumentationNode(createNodeList(docLines)), createEmptyNodeList());
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
@@ -18,6 +18,7 @@
 package io.ballerina.asyncapi.generator.http.node;
 
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.MarkdownDocumentationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
@@ -28,6 +29,7 @@ import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyMinutiaeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
@@ -43,6 +45,7 @@ import static io.ballerina.compiler.syntax.tree.NodeFactory.createConstantDeclar
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMappingConstructorExpressionNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMarkdownDocumentationNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createMetadataNode;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordFieldNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordFieldWithDefaultValueNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createRecordTypeDescriptorNode;
 import static io.ballerina.compiler.syntax.tree.NodeFactory.createSimpleNameReferenceNode;
@@ -78,17 +81,29 @@ public class GenerateListenerConfigNode {
 
     /**
      * Generates the {@code ListenerConfig} open-record type definition, with the webhook secret
-     * field plus one additional {@code string} field (default {@code ""}) per name in
-     * {@code extraConfigFields} (populated from {@code $config('name')} references in the DSL).
+     * field, one additional {@code string} field (default {@code ""}) per name in
+     * {@code extraConfigFields} (populated from {@code $config('name')} references in the DSL),
+     * and - when {@code connectionAuthConfig} is present - the outbound API auth fields matching
+     * its type/flow (e.g. {@code clientId}/{@code clientSecret}/{@code refreshToken} for an
+     * {@code oauth2} {@code authorizationCode} scheme). Secret-shaped fields (client secrets,
+     * refresh/access tokens, passwords) are required, with no default. The token/refresh URL
+     * field is defaulted to the value declared in the spec: the AsyncAPI {@code OAuthFlow}
+     * object has no way to mark a URL as varying per deployment (unlike {@code servers}, which
+     * has variables), so a fixed provider endpoint and a per-tenant one (e.g. a multi-tenant
+     * identity provider's org-scoped token URL) look identical in the spec. Defaulting - rather
+     * than hardcoding as a constant - lets the common case (a fixed global endpoint) work
+     * unmodified while still leaving the field overridable for the per-tenant case.
      *
-     * @param extraConfigFields additional configurable field names beyond {@code webhookSecret}
+     * @param extraConfigFields    additional configurable field names beyond {@code webhookSecret}
+     * @param connectionAuthConfig the resolved outbound auth configuration, if any
      * @return the generated {@link TypeDefinitionNode}
-     * @throws GeneratorException never thrown; declared for consistency with other node generators
+     * @throws GeneratorException if the connection auth configuration's type/flow is unrecognized
      */
-    public static TypeDefinitionNode generate(List<String> extraConfigFields) throws GeneratorException {
+    public static TypeDefinitionNode generate(List<String> extraConfigFields,
+            Optional<ConnectionAuthConfig> connectionAuthConfig) throws GeneratorException {
         List<Node> recordFields = new ArrayList<>();
         recordFields.add(createRecordFieldWithDefaultValueNode(
-                buildWebhookSecretDisplayMetadata(),
+                buildDisplayMetadata("Webhook Secret"),
                 null,
                 createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
                 createIdentifierToken(WEBHOOK_SECRET_FIELD),
@@ -109,6 +124,10 @@ public class GenerateListenerConfigNode {
                     createToken(SEMICOLON_TOKEN)));
         }
 
+        if (connectionAuthConfig.isPresent()) {
+            recordFields.addAll(connectionAuthFields(connectionAuthConfig.get()));
+        }
+
         RecordTypeDescriptorNode recordType = createRecordTypeDescriptorNode(
                 createToken(RECORD_KEYWORD),
                 createToken(OPEN_BRACE_TOKEN),
@@ -123,6 +142,88 @@ public class GenerateListenerConfigNode {
 
         return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
                 createIdentifierToken(LISTENER_CONFIG_TYPE), recordType, createToken(SEMICOLON_TOKEN));
+    }
+
+    /**
+     * Builds the {@code ListenerConfig} record fields required for a given outbound auth
+     * configuration, in the same field order used by the hand-written triggers this mirrors
+     * (e.g. {@code clientId}, {@code clientSecret}, {@code refreshUrl}, {@code refreshToken}).
+     *
+     * @param config the resolved outbound auth configuration
+     * @return the ordered list of generated field nodes
+     * @throws GeneratorException if the configuration's type/flow combination is unrecognized
+     */
+    private static List<Node> connectionAuthFields(ConnectionAuthConfig config) throws GeneratorException {
+        if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(config.type())) {
+            return List.of(
+                    createRequiredStringField("username"),
+                    createRequiredStringField("password"));
+        }
+        if (ConnectionAuthConfig.TYPE_OAUTH2.equals(config.type())) {
+            if (ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE.equals(config.flow())) {
+                return List.of(
+                        createRequiredStringField("clientId"),
+                        createRequiredStringField("clientSecret"),
+                        createUrlFieldWithDefault("refreshUrl", config.refreshUrl()),
+                        createRequiredStringField("refreshToken"));
+            }
+            if (ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS.equals(config.flow())) {
+                return List.of(
+                        createRequiredStringField("clientId"),
+                        createRequiredStringField("clientSecret"),
+                        createUrlFieldWithDefault("tokenUrl", config.tokenUrl()));
+            }
+        }
+        throw new GeneratorException(
+                "Unrecognized connection auth type/flow combination: " + config.type() + "/" + config.flow());
+    }
+
+    private static Node createRequiredStringField(String fieldName) {
+        return createRecordFieldNode(
+                buildDisplayMetadata(toDisplayLabel(fieldName)),
+                null,
+                createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
+                createIdentifierToken(fieldName),
+                null,
+                createToken(SEMICOLON_TOKEN));
+    }
+
+    /**
+     * Builds a {@code string} field defaulted to the URL extracted from the spec (e.g.
+     * {@code string refreshUrl = "https://oauth2.googleapis.com/token";}). Still overridable at
+     * deployment time, since the spec cannot distinguish a provider-fixed URL from a per-tenant
+     * one (see {@link #generate}).
+     */
+    private static Node createUrlFieldWithDefault(String fieldName, String url) {
+        return createRecordFieldWithDefaultValueNode(
+                buildDisplayMetadata(toDisplayLabel(fieldName)),
+                null,
+                createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
+                createIdentifierToken(fieldName),
+                createToken(EQUAL_TOKEN),
+                createBasicLiteralNode(STRING_LITERAL,
+                        createLiteralValueToken(STRING_LITERAL_TOKEN, "\"" + url + "\"",
+                                createEmptyMinutiaeList(), createEmptyMinutiaeList())),
+                createToken(SEMICOLON_TOKEN));
+    }
+
+    /**
+     * Converts a camelCase field name (e.g. {@code clientSecret}) to a display label
+     * (e.g. {@code "Client Secret"}).
+     */
+    private static String toDisplayLabel(String fieldName) {
+        StringBuilder label = new StringBuilder();
+        for (int i = 0; i < fieldName.length(); i++) {
+            char current = fieldName.charAt(i);
+            if (i == 0) {
+                label.append(Character.toUpperCase(current));
+            } else if (Character.isUpperCase(current)) {
+                label.append(' ').append(current);
+            } else {
+                label.append(current);
+            }
+        }
+        return label.toString();
     }
 
     /**
@@ -145,7 +246,7 @@ public class GenerateListenerConfigNode {
                 createToken(SEMICOLON_TOKEN));
     }
 
-    private static MetadataNode buildWebhookSecretDisplayMetadata() {
+    private static MetadataNode buildDisplayMetadata(String label) {
         AnnotationNode annotation = createAnnotationNode(
                 createToken(AT_TOKEN),
                 createSimpleNameReferenceNode(createIdentifierToken("display")),
@@ -158,7 +259,7 @@ public class GenerateListenerConfigNode {
                                         createToken(COLON_TOKEN),
                                         createBasicLiteralNode(STRING_LITERAL,
                                                 createLiteralValueToken(STRING_LITERAL_TOKEN,
-                                                        "\"Webhook Secret\"",
+                                                        "\"" + label + "\"",
                                                         createEmptyMinutiaeList(), createEmptyMinutiaeList())))),
                         createToken(CLOSE_BRACE_TOKEN)));
         return createMetadataNode(null, createNodeList(annotation));

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNode.java
@@ -28,8 +28,10 @@ import io.ballerina.compiler.syntax.tree.RecordTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyMinutiaeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
@@ -125,7 +127,19 @@ public class GenerateListenerConfigNode {
         }
 
         if (connectionAuthConfig.isPresent()) {
-            recordFields.addAll(connectionAuthFields(connectionAuthConfig.get()));
+            ConnectionAuthConfig config = connectionAuthConfig.get();
+            List<String> authFieldNames = connectionAuthFieldNames(config);
+            Set<String> existingFieldNames = new HashSet<>(extraConfigFields);
+            existingFieldNames.add(WEBHOOK_SECRET_FIELD);
+            List<String> collisions = authFieldNames.stream().filter(existingFieldNames::contains).toList();
+            if (!collisions.isEmpty()) {
+                throw new GeneratorException(
+                        "Outbound auth field name(s) " + collisions + " collide with existing webhook "
+                                + "DSL config field name(s) declared via $config('...') - rename the "
+                                + "colliding reference(s) in the webhook DSL, since generating both would "
+                                + "produce a ListenerConfig with duplicate fields that fails to compile.");
+            }
+            recordFields.addAll(connectionAuthFields(config, authFieldNames));
         }
 
         RecordTypeDescriptorNode recordType = createRecordTypeDescriptorNode(
@@ -145,37 +159,53 @@ public class GenerateListenerConfigNode {
     }
 
     /**
-     * Builds the {@code ListenerConfig} record fields required for a given outbound auth
+     * Resolves the {@code ListenerConfig} field names required for a given outbound auth
      * configuration, in the same field order used by the hand-written triggers this mirrors
      * (e.g. {@code clientId}, {@code clientSecret}, {@code refreshUrl}, {@code refreshToken}).
+     * The single source of truth for both the field-name-collision check in {@link #generate}
+     * and the actual field nodes built by {@link #connectionAuthFields}.
      *
      * @param config the resolved outbound auth configuration
-     * @return the ordered list of generated field nodes
+     * @return the ordered list of required field names
      * @throws GeneratorException if the configuration's type/flow combination is unrecognized
      */
-    private static List<Node> connectionAuthFields(ConnectionAuthConfig config) throws GeneratorException {
+    private static List<String> connectionAuthFieldNames(ConnectionAuthConfig config) throws GeneratorException {
         if (ConnectionAuthConfig.TYPE_USER_PASSWORD.equals(config.type())) {
-            return List.of(
-                    createRequiredStringField("username"),
-                    createRequiredStringField("password"));
+            return List.of("username", "password");
         }
         if (ConnectionAuthConfig.TYPE_OAUTH2.equals(config.type())) {
             if (ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE.equals(config.flow())) {
-                return List.of(
-                        createRequiredStringField("clientId"),
-                        createRequiredStringField("clientSecret"),
-                        createUrlFieldWithDefault("refreshUrl", config.refreshUrl()),
-                        createRequiredStringField("refreshToken"));
+                return List.of("clientId", "clientSecret", "refreshUrl", "refreshToken");
             }
             if (ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS.equals(config.flow())) {
-                return List.of(
-                        createRequiredStringField("clientId"),
-                        createRequiredStringField("clientSecret"),
-                        createUrlFieldWithDefault("tokenUrl", config.tokenUrl()));
+                return List.of("clientId", "clientSecret", "tokenUrl");
             }
         }
         throw new GeneratorException(
                 "Unrecognized connection auth type/flow combination: " + config.type() + "/" + config.flow());
+    }
+
+    /**
+     * Builds the {@code ListenerConfig} record field nodes for the given field names, using a
+     * defaulted URL field for {@code refreshUrl}/{@code tokenUrl} and a plain required field for
+     * everything else (see {@link #createUrlFieldWithDefault} and {@link #createRequiredStringField}).
+     *
+     * @param config     the resolved outbound auth configuration (source of the URL default values)
+     * @param fieldNames the field names to build, as resolved by {@link #connectionAuthFieldNames}
+     * @return the ordered list of generated field nodes
+     */
+    private static List<Node> connectionAuthFields(ConnectionAuthConfig config, List<String> fieldNames) {
+        List<Node> fields = new ArrayList<>();
+        for (String fieldName : fieldNames) {
+            if ("refreshUrl".equals(fieldName)) {
+                fields.add(createUrlFieldWithDefault(fieldName, config.refreshUrl()));
+            } else if ("tokenUrl".equals(fieldName)) {
+                fields.add(createUrlFieldWithDefault(fieldName, config.tokenUrl()));
+            } else {
+                fields.add(createRequiredStringField(fieldName));
+            }
+        }
+        return fields;
     }
 
     private static Node createRequiredStringField(String fieldName) {

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/HttpCodeGeneratorIntegrationTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/HttpCodeGeneratorIntegrationTest.java
@@ -165,6 +165,90 @@ public class HttpCodeGeneratorIntegrationTest {
     }
 
     @Test
+    void testGenerateWithOAuth2AuthorizationCodeConnectionAuth() throws Exception {
+        Path spec = specPath("connection_auth_oauth2_authcode.json");
+        Path outDir = Files.createTempDirectory("oauth2-authcode-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertTrue(
+                    types.contains("refreshUrl = \"https://oauth2.googleapis.com/token\""),
+                    "ListenerConfig should declare a refreshUrl field defaulted to the spec's refreshUrl");
+            Assert.assertTrue(types.contains("clientId"), "ListenerConfig should declare a clientId field");
+            Assert.assertTrue(types.contains("clientSecret"), "ListenerConfig should declare a clientSecret field");
+            Assert.assertTrue(types.contains("refreshToken"), "ListenerConfig should declare a refreshToken field");
+            Assert.assertFalse(types.contains("username"),
+                    "authorizationCode flow should not generate username/password fields");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
+    void testGenerateWithOAuth2ClientCredentialsConnectionAuth() throws Exception {
+        Path spec = specPath("connection_auth_oauth2_clientcreds.json");
+        Path outDir = Files.createTempDirectory("oauth2-clientcreds-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertTrue(
+                    types.contains("tokenUrl = \"https://api.example.com/oauth/token\""),
+                    "ListenerConfig should declare a tokenUrl field defaulted to the spec's tokenUrl");
+            Assert.assertTrue(types.contains("clientId"), "ListenerConfig should declare a clientId field");
+            Assert.assertTrue(types.contains("clientSecret"), "ListenerConfig should declare a clientSecret field");
+            Assert.assertFalse(types.contains("refreshToken"),
+                    "clientCredentials flow should not generate a refreshToken field");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
+    void testGenerateWithUserPasswordConnectionAuth() throws Exception {
+        Path spec = specPath("connection_auth_userpassword.json");
+        Path outDir = Files.createTempDirectory("userpassword-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertFalse(types.contains("refreshUrl") || types.contains("tokenUrl"),
+                    "userPassword has no token/refresh endpoint, so no URL field should be generated");
+            Assert.assertTrue(types.contains("username"), "ListenerConfig should declare a username field");
+            Assert.assertTrue(types.contains("password"), "ListenerConfig should declare a password field");
+            Assert.assertFalse(types.contains("clientId"),
+                    "userPassword should not generate OAuth2 client fields");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
+    void testGenerateWithNoSecuritySchemesOmitsConnectionAuthArtifacts() throws Exception {
+        // Regression check: a spec with no components.securitySchemes at all must generate
+        // exactly what it did before this feature existed -- none of the extra credential
+        // or URL fields.
+        Path spec = specPath("sendgrid_minimal.json");
+        Path outDir = Files.createTempDirectory("no-connection-auth-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertFalse(types.contains("clientId"), "No OAuth2 fields should be generated");
+            Assert.assertFalse(types.contains("username"), "No userPassword fields should be generated");
+            Assert.assertFalse(types.contains("refreshUrl") || types.contains("tokenUrl"),
+                    "No connection-auth URL field should be generated");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
     void testGenerateMissingEventIdentifierThrows() throws Exception {
         Path spec = specPath("missing_event_identifier.json");
         AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/HttpCodeGeneratorIntegrationTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/HttpCodeGeneratorIntegrationTest.java
@@ -228,6 +228,64 @@ public class HttpCodeGeneratorIntegrationTest {
     }
 
     @Test
+    void testGenerateWithHttpApiKeyConnectionAuth() throws Exception {
+        Path spec = specPath("connection_auth_httpapikey.json");
+        Path outDir = Files.createTempDirectory("httpapikey-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertTrue(types.contains("apiKeyValue"), "ListenerConfig should declare an apiKeyValue field");
+            Assert.assertTrue(types.contains("API key sent as the 'X-API-Key' HTTP header"),
+                    "Field doc comment should name the header and location");
+            Assert.assertFalse(types.contains("@display"), "Generated fields should use doc comments, not @display");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
+    void testGenerateWithX509ConnectionAuth() throws Exception {
+        Path spec = specPath("connection_auth_x509.json");
+        Path outDir = Files.createTempDirectory("x509-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertTrue(types.contains("crypto:TrustStore|string cert"),
+                    "ListenerConfig should declare a crypto:TrustStore|string cert field");
+            Assert.assertTrue(types.contains("crypto:KeyStore|http:CertKey keyConfig"),
+                    "ListenerConfig should declare a crypto:KeyStore|http:CertKey keyConfig field");
+            Assert.assertTrue(types.contains("import ballerina/crypto;"),
+                    "data_types.bal should import ballerina/crypto for the X509 union fields");
+            Assert.assertFalse(types.contains("@display"), "Generated fields should use doc comments, not @display");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
+    void testGenerateWithoutX509OmitsCryptoImport() throws Exception {
+        // Regression check for the conditional crypto import's false branch -- without this,
+        // replacing the `if` in DataTypesGenerator with an unconditional import would go
+        // unnoticed by every other test here (they only check for the import's presence).
+        Path spec = specPath("connection_auth_userpassword.json");
+        Path outDir = Files.createTempDirectory("no-x509-gen");
+        try {
+            AsyncApiSpec asyncApiSpec = AsyncApiParser.parseFromJsonString(Files.readString(spec));
+            new HttpCodeGenerator(asyncApiSpec).generate(outDir);
+
+            String types = readFile(outDir, "data_types.bal");
+            Assert.assertFalse(types.contains("import ballerina/crypto;"),
+                    "data_types.bal should not import ballerina/crypto unless X509 is in use");
+        } finally {
+            deleteDir(outDir);
+        }
+    }
+
+    @Test
     void testGenerateWithNoSecuritySchemesOmitsConnectionAuthArtifacts() throws Exception {
         // Regression check: a spec with no components.securitySchemes at all must generate
         // exactly what it did before this feature existed -- none of the extra credential
@@ -243,6 +301,9 @@ public class HttpCodeGeneratorIntegrationTest {
             Assert.assertFalse(types.contains("username"), "No userPassword fields should be generated");
             Assert.assertFalse(types.contains("refreshUrl") || types.contains("tokenUrl"),
                     "No connection-auth URL field should be generated");
+            Assert.assertFalse(types.contains("@display"),
+                    "webhookSecret should use a doc comment, not @display, even with no connection auth");
+            Assert.assertTrue(types.contains("Webhook Secret"), "webhookSecret field should have a doc comment");
         } finally {
             deleteDir(outDir);
         }

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
@@ -131,6 +131,17 @@ public class WebhookDSLVerificationTest {
         "Invalid input token in webhook DSL");
     }
 
+    @Test
+    public void testConnectionAuthFieldCollisionWithWebhookDslConfigFieldThrows() throws Exception {
+        // The webhook DSL declares $config('clientId'), and the spec also declares an oauth2
+        // clientCredentials securityScheme, which generates its own "clientId" field. Both would
+        // land in the same ListenerConfig record under the same name, producing invalid Ballerina
+        // source (duplicate field) if not caught explicitly.
+        assertGeneratorException(
+                "connection_auth_field_collision.yaml",
+                "collide with existing webhook DSL config field name(s)");
+    }
+
     private String generateDispatcherService(String specFile) throws Exception {
     Path asyncapiPath = RES_DIR.resolve(specFile);
     String yamlContent = Files.readString(asyncapiPath);

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
@@ -142,6 +142,23 @@ public class WebhookDSLVerificationTest {
                 "collide with existing webhook DSL config field name(s)");
     }
 
+    @Test
+    public void testHttpApiKeyFieldCollisionWithWebhookDslConfigFieldThrows() throws Exception {
+        // Same collision check, exercised through the real DSL-parsing -> extractor ->
+        // collision-check path end to end, for the newly-added httpApiKey mechanism.
+        assertGeneratorException(
+                "connection_auth_field_collision_httpapikey.yaml",
+                "collide with existing webhook DSL config field name(s)");
+    }
+
+    @Test
+    public void testX509FieldCollisionWithWebhookDslConfigFieldThrows() throws Exception {
+        // Same collision check, exercised end to end, for the newly-added X509 mechanism.
+        assertGeneratorException(
+                "connection_auth_field_collision_x509.yaml",
+                "collide with existing webhook DSL config field name(s)");
+    }
+
     private String generateDispatcherService(String specFile) throws Exception {
     Path asyncapiPath = RES_DIR.resolve(specFile);
     String yamlContent = Files.readString(asyncapiPath);

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.asyncapi.generator.http.extractor;
+
+import io.ballerina.asyncapi.core.AsyncApiParser;
+import io.ballerina.asyncapi.core.AsyncApiParserException;
+import io.ballerina.asyncapi.core.api.AsyncApiSpec;
+import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link ConnectionAuthExtractor} covering all supported scheme/flow
+ * combinations, the no-scheme case, and the unsupported-flow error branch.
+ */
+public class ConnectionAuthExtractorTest {
+
+    private static final String PREFIX = "{\"asyncapi\":\"2.0.0\",\"info\":{\"title\":\"T\",\"version\":\"1\"}"
+            + ",\"channels\":{}";
+
+    @Test
+    void testNoComponentsReturnsEmpty() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + "}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+        Assert.assertTrue(result.isEmpty(), "Spec with no components should return empty");
+    }
+
+    @Test
+    void testNoSecuritySchemesReturnsEmpty() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"schemas\":{}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+        Assert.assertTrue(result.isEmpty(), "Spec with no securitySchemes should return empty");
+    }
+
+    @Test
+    void testUnrelatedSchemeTypeReturnsEmpty() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"apiKey\",\"in\":\"header\",\"name\":\"X-Api-Key\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+        Assert.assertTrue(result.isEmpty(), "apiKey scheme type is out of scope and should return empty");
+    }
+
+    @Test
+    void testUserPasswordScheme() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"basicAuth\":"
+                + "{\"type\":\"userPassword\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "userPassword scheme should be extracted");
+        Assert.assertEquals(result.get().type(), ConnectionAuthConfig.TYPE_USER_PASSWORD);
+        Assert.assertNull(result.get().flow(), "userPassword has no OAuth flow");
+        Assert.assertNull(result.get().tokenUrl());
+        Assert.assertNull(result.get().refreshUrl());
+    }
+
+    @Test
+    void testOAuth2AuthorizationCodeFlow() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{\"authorizationCode\":"
+                + "{\"authorizationUrl\":\"https://example.com/authorize\","
+                + "\"tokenUrl\":\"https://example.com/token\","
+                + "\"refreshUrl\":\"https://example.com/refresh\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "oauth2 authorizationCode scheme should be extracted");
+        Assert.assertEquals(result.get().type(), ConnectionAuthConfig.TYPE_OAUTH2);
+        Assert.assertEquals(result.get().flow(), ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE);
+        Assert.assertEquals(result.get().refreshUrl(), "https://example.com/refresh");
+        Assert.assertNull(result.get().tokenUrl(), "authorizationCode flow should not populate tokenUrl");
+    }
+
+    @Test
+    void testOAuth2ClientCredentialsFlow() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{\"clientCredentials\":"
+                + "{\"tokenUrl\":\"https://example.com/token\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "oauth2 clientCredentials scheme should be extracted");
+        Assert.assertEquals(result.get().type(), ConnectionAuthConfig.TYPE_OAUTH2);
+        Assert.assertEquals(result.get().flow(), ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS);
+        Assert.assertEquals(result.get().tokenUrl(), "https://example.com/token");
+        Assert.assertNull(result.get().refreshUrl(), "clientCredentials flow should not populate refreshUrl");
+    }
+
+    @Test
+    void testOAuth2AuthorizationCodeMissingRefreshUrlThrows() throws AsyncApiParserException {
+        // tokenUrl and scopes are required by the AsyncAPI spec itself for authorizationCode,
+        // so the parser accepts this; refreshUrl is spec-optional, so its absence is only
+        // caught by our own extractor, not by upstream spec validation.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{\"authorizationCode\":"
+                + "{\"authorizationUrl\":\"https://example.com/authorize\","
+                + "\"tokenUrl\":\"https://example.com/token\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for authorizationCode flow missing refreshUrl");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("refreshUrl"),
+                    "Exception should mention the missing refreshUrl");
+        }
+    }
+
+    @Test
+    void testOAuth2ClientCredentialsMalformedTokenUrlThrows() throws AsyncApiParserException {
+        // The AsyncAPI spec requires clientCredentials to declare a tokenUrl, so a spec-valid
+        // fixture can never omit it outright (the parser itself rejects that). A malformed URI
+        // string still satisfies the parser's string/presence check but fails java.net.URI
+        // parsing, so it surfaces to our extractor as a null tokenUrl -- the one way this guard
+        // is still reachable through a real parsed spec.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{\"clientCredentials\":"
+                + "{\"tokenUrl\":\"not a valid uri\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for clientCredentials flow with an unparsable tokenUrl");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("tokenUrl"),
+                    "Exception should mention the missing tokenUrl");
+        }
+    }
+
+    @Test
+    void testOAuth2UnsupportedFlowThrows() throws AsyncApiParserException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{\"implicit\":"
+                + "{\"authorizationUrl\":\"https://example.com/authorize\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for unsupported oauth2 flow (implicit only)");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("Unsupported oauth2 flow"),
+                    "Exception should identify the flow as unsupported");
+        }
+    }
+}

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
@@ -252,6 +252,31 @@ public class ConnectionAuthExtractorTest {
     }
 
     @Test
+    void testOAuth2BothFlowsOnSameSchemeThrows() throws AsyncApiParserException {
+        // A single oauth2 scheme declaring both flows is genuinely ambiguous for the generated
+        // trigger's outbound calls - the spec has no way to say which flow this trigger should
+        // actually use, so this must fail loudly rather than silently preferring
+        // authorizationCode.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
+                + "{\"type\":\"oauth2\",\"flows\":{"
+                + "\"authorizationCode\":{\"authorizationUrl\":\"https://example.com/authorize\","
+                + "\"tokenUrl\":\"https://example.com/token\","
+                + "\"refreshUrl\":\"https://example.com/refresh\","
+                + "\"scopes\":{\"read\":\"Read access\"}},"
+                + "\"clientCredentials\":{\"tokenUrl\":\"https://example.com/token\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for a scheme declaring both oauth2 flows");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("authorizationCode")
+                            && e.getMessage().contains("clientCredentials"),
+                    "Exception should name both conflicting flows: " + e.getMessage());
+        }
+    }
+
+    @Test
     void testOAuth2AuthorizationCodeMissingRefreshUrlThrows() throws AsyncApiParserException {
         // tokenUrl and scopes are required by the AsyncAPI spec itself for authorizationCode,
         // so the parser accepts this; refreshUrl is spec-optional, so its absence is only

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
@@ -76,6 +76,28 @@ public class ConnectionAuthExtractorTest {
     }
 
     @Test
+    void testMultipleRecognizedSchemesThrows() throws AsyncApiParserException {
+        // Two recognized scheme entries in the same spec -- which one the trigger should
+        // actually use is ambiguous, so this must fail loudly rather than silently picking
+        // whichever one the map iterates to first.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{"
+                + "\"basicAuth\":{\"type\":\"userPassword\"},"
+                + "\"oauthAuth\":{\"type\":\"oauth2\",\"flows\":{\"clientCredentials\":"
+                + "{\"tokenUrl\":\"https://example.com/token\","
+                + "\"scopes\":{\"read\":\"Read access\"}}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for multiple recognized auth schemes");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("Multiple outbound auth schemes"),
+                    "Exception should identify the ambiguity: " + e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("basicAuth") && e.getMessage().contains("oauthAuth"),
+                    "Exception should name both conflicting scheme keys: " + e.getMessage());
+        }
+    }
+
+    @Test
     void testOAuth2AuthorizationCodeFlow() throws AsyncApiParserException, GeneratorException {
         String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
                 + "{\"type\":\"oauth2\",\"flows\":{\"authorizationCode\":"

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/extractor/ConnectionAuthExtractorTest.java
@@ -98,6 +98,126 @@ public class ConnectionAuthExtractorTest {
     }
 
     @Test
+    void testMultipleRecognizedSchemesIncludingNewTypesThrows() throws AsyncApiParserException {
+        // Same ambiguity guard, but proving it generalizes to the two new types too, not just
+        // the original oauth2/userPassword pair.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{"
+                + "\"apiKeyAuth\":{\"type\":\"httpApiKey\",\"name\":\"X-API-Key\",\"in\":\"header\"},"
+                + "\"mtlsAuth\":{\"type\":\"X509\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for multiple recognized auth schemes");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("Multiple outbound auth schemes"),
+                    "Exception should identify the ambiguity: " + e.getMessage());
+            Assert.assertTrue(e.getMessage().contains("apiKeyAuth") && e.getMessage().contains("mtlsAuth"),
+                    "Exception should name both conflicting scheme keys: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testHttpApiKeyHeaderScheme() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"httpApiKey\",\"name\":\"X-API-Key\",\"in\":\"header\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "httpApiKey scheme should be extracted");
+        Assert.assertEquals(result.get().type(), ConnectionAuthConfig.TYPE_HTTP_API_KEY);
+        Assert.assertEquals(result.get().apiKeyName(), "X-API-Key");
+        Assert.assertEquals(result.get().apiKeyIn(), ConnectionAuthConfig.API_KEY_IN_HEADER);
+        Assert.assertNull(result.get().flow(), "httpApiKey has no OAuth flow");
+    }
+
+    @Test
+    void testHttpApiKeyQueryScheme() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"httpApiKey\",\"name\":\"api_key\",\"in\":\"query\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "httpApiKey scheme should be extracted");
+        Assert.assertEquals(result.get().apiKeyName(), "api_key");
+        Assert.assertEquals(result.get().apiKeyIn(), ConnectionAuthConfig.API_KEY_IN_QUERY);
+    }
+
+    @Test
+    void testHttpApiKeyCookieScheme() throws AsyncApiParserException, GeneratorException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"httpApiKey\",\"name\":\"session_key\",\"in\":\"cookie\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "httpApiKey scheme should be extracted");
+        Assert.assertEquals(result.get().apiKeyName(), "session_key");
+        Assert.assertEquals(result.get().apiKeyIn(), ConnectionAuthConfig.API_KEY_IN_COOKIE);
+    }
+
+    @Test
+    void testHttpApiKeyMissingNameThrows() throws AsyncApiParserException {
+        // A name that's entirely absent is already rejected by the upstream AsyncAPI parser
+        // itself ("API Key Security Scheme is missing a parameter name"), before this ever
+        // reaches our extractor - so a spec-valid fixture can't omit the field outright (same
+        // situation as testOAuth2ClientCredentialsMalformedTokenUrlThrows above). A blank string
+        // satisfies the parser's presence check but still fails our own isBlank() guard, which is
+        // the one way this branch is reachable through a real parsed spec.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"httpApiKey\",\"name\":\"\",\"in\":\"header\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for httpApiKey scheme with a blank name");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("'name'"),
+                    "Exception should mention the missing name: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testHttpApiKeyInvalidInThrows() throws AsyncApiParserException {
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"httpApiKey\",\"name\":\"X-API-Key\",\"in\":\"body\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        try {
+            new ConnectionAuthExtractor(spec).extract();
+            Assert.fail("Expected GeneratorException for httpApiKey scheme with an invalid 'in' value");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("'in'"),
+                    "Exception should mention the invalid in value: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testX509Scheme() throws AsyncApiParserException, GeneratorException {
+        // AsyncAPI intentionally carries no certificate material in the spec itself -- the
+        // scheme just declares that mutual TLS is required.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"mtlsAuth\":"
+                + "{\"type\":\"X509\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+
+        Assert.assertTrue(result.isPresent(), "X509 scheme should be extracted");
+        Assert.assertEquals(result.get().type(), ConnectionAuthConfig.TYPE_X509);
+        Assert.assertNull(result.get().flow());
+        Assert.assertNull(result.get().tokenUrl());
+        Assert.assertNull(result.get().refreshUrl());
+        Assert.assertNull(result.get().apiKeyName());
+        Assert.assertNull(result.get().apiKeyIn());
+    }
+
+    @Test
+    void testApiKeyTypeStaysUnrelatedDistinctFromHttpApiKey() throws AsyncApiParserException, GeneratorException {
+        // apiKey (generic, non-HTTP) and httpApiKey (supported) are different `type` strings --
+        // locking this in explicitly so a future "fix" can't silently conflate the two.
+        String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"apiKeyAuth\":"
+                + "{\"type\":\"apiKey\",\"in\":\"user\"}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        Optional<ConnectionAuthConfig> result = new ConnectionAuthExtractor(spec).extract();
+        Assert.assertTrue(result.isEmpty(), "apiKey (not httpApiKey) is still out of scope");
+    }
+
+    @Test
     void testOAuth2AuthorizationCodeFlow() throws AsyncApiParserException, GeneratorException {
         String json = PREFIX + ",\"components\":{\"securitySchemes\":{\"oauthAuth\":"
                 + "{\"type\":\"oauth2\",\"flows\":{\"authorizationCode\":"

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
@@ -19,6 +19,8 @@ package io.ballerina.asyncapi.generator.http.generator;
 
 import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
+import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -103,7 +105,8 @@ public class DataTypesGeneratorTest {
         schemas.put("Installation", installation);
         schemas.put("PushPayload", pushPayload);
 
-        String result = new DataTypesGenerator(schemas, Optional.empty()).generate();
+        String result = new DataTypesGenerator(schemas, Optional.<WebhookAuthConfig>empty(),
+                Optional.<ConnectionAuthConfig>empty()).generate();
 
         int unionStart = result.indexOf("public type GenericDataType");
         Assert.assertTrue(unionStart >= 0, "Expected a GenericDataType union declaration: " + result);
@@ -131,7 +134,8 @@ public class DataTypesGeneratorTest {
         schemas.put("FirstPayload", first);
         schemas.put("SecondPayload", second);
 
-        String result = new DataTypesGenerator(schemas, Optional.empty()).generate();
+        String result = new DataTypesGenerator(schemas, Optional.<WebhookAuthConfig>empty(),
+                Optional.<ConnectionAuthConfig>empty()).generate();
 
         int unionStart = result.indexOf("public type GenericDataType");
         String unionDecl = result.substring(unionStart, result.indexOf(';', unionStart));

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.asyncapi.generator.http.generator;
 
 import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
 import io.ballerina.asyncapi.generator.http.model.HttpRemoteFunction;
 import io.ballerina.asyncapi.generator.http.model.HttpServiceType;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
@@ -43,7 +44,8 @@ public class ListenerGeneratorTest {
                         new HttpRemoteFunction("issues.opened", "IssueEvent")
                 ))
         );
-        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty()).generate();
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty(),
+                Optional.<ConnectionAuthConfig>empty()).generate();
 
         Assert.assertFalse(source.isBlank(), "Generated listener source should not be blank");
         Assert.assertTrue(source.contains("Listener"),
@@ -56,12 +58,38 @@ public class ListenerGeneratorTest {
                 "Generated source should reference IssueService in getServiceTypeStr");
         Assert.assertTrue(source.contains("http"),
                 "Generated source should import the ballerina/http module");
+        Assert.assertTrue(source.contains("ListenerConfig listenerConfig = {webhookSecret: DEFAULT_SECRET}"),
+                "With no connection auth, listenerConfig should stay defaultable");
+    }
+
+    @Test
+    void testGenerateWithConnectionAuthMakesListenerConfigRequired() throws GeneratorException {
+        // Regression check for the listener.bal compile bug (#9028): once connection auth
+        // contributes required fields (e.g. username/password) with no safe default, the
+        // listenerConfig parameter itself must become a required parameter - a partial default
+        // like {webhookSecret: DEFAULT_SECRET} would leave those required fields unset, which
+        // Ballerina rejects outright.
+        List<HttpServiceType> serviceTypes = List.of(
+                new HttpServiceType("RepositoryService", List.of(
+                        new HttpRemoteFunction("push", "PushEvent")
+                ))
+        );
+        ConnectionAuthConfig connectionAuthConfig = new ConnectionAuthConfig(
+                ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null);
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty(),
+                Optional.of(connectionAuthConfig)).generate();
+
+        Assert.assertTrue(source.contains("ListenerConfig listenerConfig,"),
+                "With connection auth present, listenerConfig should be a required parameter: " + source);
+        Assert.assertFalse(source.contains("listenerConfig = {webhookSecret"),
+                "listenerConfig should not carry a partial default value: " + source);
     }
 
     @Test
     void testEmptyServiceTypesThrows() {
         try {
-            new ListenerGenerator(List.of(), Optional.<WebhookAuthConfig>empty()).generate();
+            new ListenerGenerator(List.of(), Optional.<WebhookAuthConfig>empty(),
+                    Optional.<ConnectionAuthConfig>empty()).generate();
             Assert.fail("Expected GeneratorException for empty service types list");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");
@@ -71,7 +99,8 @@ public class ListenerGeneratorTest {
     @Test
     void testNullServiceTypesThrows() {
         try {
-            new ListenerGenerator(null, Optional.<WebhookAuthConfig>empty()).generate();
+            new ListenerGenerator(null, Optional.<WebhookAuthConfig>empty(),
+                    Optional.<ConnectionAuthConfig>empty()).generate();
             Assert.fail("Expected GeneratorException for null service types");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNodeTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNodeTest.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.asyncapi.generator.http.node;
+
+import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.ConnectionAuthConfig;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link GenerateListenerConfigNode}, asserting directly on the generated node's
+ * source text ({@link TypeDefinitionNode#toString()}) rather than round-tripping through the
+ * parser/formatter - the cheapest way to exercise every {@code connectionAuthFieldNames}/
+ * {@code connectionAuthFields} branch, including the doc-comment-vs-{@code @display} retrofit.
+ */
+public class GenerateListenerConfigNodeTest {
+
+    @Test
+    void testGenerateNoConnectionAuthWebhookSecretDocCommentOnly() throws GeneratorException {
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.empty()).toString();
+        Assert.assertTrue(result.contains("#Webhook Secret"),
+                "webhookSecret field should carry a doc comment: " + result);
+        Assert.assertFalse(result.contains("@display"),
+                "No field should use a @display annotation anymore: " + result);
+    }
+
+    @Test
+    void testGenerateUserPasswordDocCommentNotDisplay() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(
+                ConnectionAuthConfig.TYPE_USER_PASSWORD, null, null, null);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("username"), "Should declare a username field: " + result);
+        Assert.assertTrue(result.contains("password"), "Should declare a password field: " + result);
+        Assert.assertTrue(result.contains("#Username"), "username field should have a doc comment: " + result);
+        Assert.assertTrue(result.contains("#Password"), "password field should have a doc comment: " + result);
+        Assert.assertFalse(result.contains("@display"),
+                "Retrofit: userPassword fields must not use @display anymore: " + result);
+    }
+
+    @Test
+    void testGenerateOAuth2AuthorizationCodeStillWorks() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2,
+                ConnectionAuthConfig.FLOW_AUTHORIZATION_CODE, null, "https://example.com/refresh");
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("clientId"), "Should declare a clientId field: " + result);
+        Assert.assertTrue(result.contains("clientSecret"), "Should declare a clientSecret field: " + result);
+        Assert.assertTrue(result.contains("refreshUrl"), "Should declare a refreshUrl field: " + result);
+        Assert.assertTrue(result.contains("refreshToken"), "Should declare a refreshToken field: " + result);
+        Assert.assertTrue(result.contains("https://example.com/refresh"),
+                "refreshUrl should default to the spec's value: " + result);
+        Assert.assertFalse(result.contains("@display"), "Retrofit regression: " + result);
+    }
+
+    @Test
+    void testGenerateOAuth2ClientCredentialsStillWorks() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2,
+                ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS, "https://example.com/token", null);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("clientId"), "Should declare a clientId field: " + result);
+        Assert.assertTrue(result.contains("clientSecret"), "Should declare a clientSecret field: " + result);
+        Assert.assertTrue(result.contains("tokenUrl"), "Should declare a tokenUrl field: " + result);
+        Assert.assertFalse(result.contains("refreshToken"),
+                "clientCredentials flow should not generate a refreshToken field: " + result);
+        Assert.assertFalse(result.contains("@display"), "Retrofit regression: " + result);
+    }
+
+    @Test
+    void testGenerateHttpApiKeyHeaderDynamicDescription() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_HTTP_API_KEY,
+                null, null, null, "X-API-Key", ConnectionAuthConfig.API_KEY_IN_HEADER);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("apiKeyValue"), "Should declare an apiKeyValue field: " + result);
+        Assert.assertTrue(result.contains("#API key sent as the 'X-API-Key' HTTP header"),
+                "Doc comment should name the header and location: " + result);
+        Assert.assertFalse(result.contains("@display"), "httpApiKey field must use a doc comment: " + result);
+    }
+
+    @Test
+    void testGenerateHttpApiKeyQueryDynamicDescription() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_HTTP_API_KEY,
+                null, null, null, "api_key", ConnectionAuthConfig.API_KEY_IN_QUERY);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("#API key sent as the 'api_key' HTTP query"),
+                "Doc comment text should be dynamic, not hardcoded to 'header': " + result);
+    }
+
+    @Test
+    void testGenerateHttpApiKeyCookieDynamicDescription() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_HTTP_API_KEY,
+                null, null, null, "session_key", ConnectionAuthConfig.API_KEY_IN_COOKIE);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("#API key sent as the 'session_key' HTTP cookie"),
+                "Doc comment text should be dynamic, not hardcoded to 'header': " + result);
+    }
+
+    @Test
+    void testGenerateX509UnionFields() throws GeneratorException {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_X509, null, null, null);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("crypto:TrustStore"),
+                "cert field should reference crypto:TrustStore: " + result);
+        Assert.assertTrue(result.contains("cert"), "Should declare a cert field: " + result);
+        Assert.assertTrue(result.contains("crypto:KeyStore"),
+                "keyConfig field should reference crypto:KeyStore: " + result);
+        Assert.assertTrue(result.contains("http:CertKey"),
+                "keyConfig field should reference http:CertKey: " + result);
+        Assert.assertTrue(result.contains("keyConfig"), "Should declare a keyConfig field: " + result);
+        Assert.assertTrue(result.contains("#Client certificate for mutual TLS"),
+                "cert field should have a doc comment: " + result);
+        Assert.assertTrue(result.contains("#Client private key for mutual TLS"),
+                "keyConfig field should have a doc comment: " + result);
+        Assert.assertFalse(result.contains("@display"), "X509 fields must use doc comments: " + result);
+    }
+
+    @Test
+    void testGenerateHttpApiKeyValueCollidesWithExtraConfigFieldThrows() {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_HTTP_API_KEY,
+                null, null, null, "X-API-Key", ConnectionAuthConfig.API_KEY_IN_HEADER);
+        try {
+            GenerateListenerConfigNode.generate(List.of("apiKeyValue"), Optional.of(config));
+            Assert.fail("Expected GeneratorException for apiKeyValue field name collision");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("apiKeyValue"),
+                    "Exception should name the colliding field: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGenerateX509CertCollidesWithExtraConfigFieldThrows() {
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_X509, null, null, null);
+        try {
+            GenerateListenerConfigNode.generate(List.of("cert"), Optional.of(config));
+            Assert.fail("Expected GeneratorException for cert field name collision");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("cert"),
+                    "Exception should name the colliding field: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testGenerateUnrecognizedTypeFlowThrows() {
+        // oauth2 with no flow set at all doesn't match either the authorizationCode or
+        // clientCredentials branch inside connectionAuthFieldNames - the final throw at the
+        // bottom of that method, otherwise untested even for the 3 pre-existing mechanisms.
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2, null, null, null);
+        try {
+            GenerateListenerConfigNode.generate(List.of(), Optional.of(config));
+            Assert.fail("Expected GeneratorException for an unrecognized type/flow combination");
+        } catch (GeneratorException e) {
+            Assert.assertTrue(e.getMessage().contains("Unrecognized connection auth type/flow"),
+                    "Exception should identify the combination as unrecognized: " + e.getMessage());
+        }
+    }
+}

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNodeTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerConfigNodeTest.java
@@ -87,6 +87,21 @@ public class GenerateListenerConfigNodeTest {
     }
 
     @Test
+    void testGenerateTokenUrlWithQuoteIsEscaped() throws GeneratorException {
+        // A tokenUrl/refreshUrl containing a literal '"' must not be embedded raw into the
+        // generated string literal - doing so would prematurely close it and produce malformed
+        // generated source. Contrived input, but proves the escape actually runs.
+        ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_OAUTH2,
+                ConnectionAuthConfig.FLOW_CLIENT_CREDENTIALS, "https://example.com/token?q=\"quoted\"", null);
+        String result = GenerateListenerConfigNode.generate(List.of(), Optional.of(config)).toString();
+
+        Assert.assertTrue(result.contains("https://example.com/token?q=\\\"quoted\\\""),
+                "Embedded quote should be escaped, not left raw: " + result);
+        Assert.assertFalse(result.contains("q=\"quoted\"\";"),
+                "Unescaped quote would prematurely close the string literal: " + result);
+    }
+
+    @Test
     void testGenerateHttpApiKeyHeaderDynamicDescription() throws GeneratorException {
         ConnectionAuthConfig config = new ConnectionAuthConfig(ConnectionAuthConfig.TYPE_HTTP_API_KEY,
                 null, null, null, "X-API-Key", ConnectionAuthConfig.API_KEY_IN_HEADER);

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision.yaml
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision.yaml
@@ -1,0 +1,30 @@
+asyncapi: 2.6.0
+x-ballerina-event-identifier:
+  type: "header"
+  name: "X-Test-Event"
+x-ballerina-auth:
+  header: X-Test-Signature
+  signature:
+    algorithm: sha256
+    encoding: hex
+    headerFormat: $signature
+    input: "$config('clientId') . $body"
+info:
+  title: Field Collision Test
+  version: 1.0.0
+channels:
+  events:
+    subscribe:
+      message:
+        x-ballerina-event-type: test_event
+        payload:
+          type: object
+components:
+  securitySchemes:
+    clientCredentialsAuth:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://api.example.com/oauth/token
+          scopes:
+            read: Read access

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision_httpapikey.yaml
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision_httpapikey.yaml
@@ -1,0 +1,27 @@
+asyncapi: 2.6.0
+x-ballerina-event-identifier:
+  type: "header"
+  name: "X-Test-Event"
+x-ballerina-auth:
+  header: X-Test-Signature
+  signature:
+    algorithm: sha256
+    encoding: hex
+    headerFormat: $signature
+    input: "$config('apiKeyValue') . $body"
+info:
+  title: httpApiKey Field Collision Test
+  version: 1.0.0
+channels:
+  events:
+    subscribe:
+      message:
+        x-ballerina-event-type: test_event
+        payload:
+          type: object
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: httpApiKey
+      name: X-API-Key
+      in: header

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision_x509.yaml
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_field_collision_x509.yaml
@@ -1,0 +1,25 @@
+asyncapi: 2.6.0
+x-ballerina-event-identifier:
+  type: "header"
+  name: "X-Test-Event"
+x-ballerina-auth:
+  header: X-Test-Signature
+  signature:
+    algorithm: sha256
+    encoding: hex
+    headerFormat: $signature
+    input: "$config('cert') . $body"
+info:
+  title: X509 Field Collision Test
+  version: 1.0.0
+channels:
+  events:
+    subscribe:
+      message:
+        x-ballerina-event-type: test_event
+        payload:
+          type: object
+components:
+  securitySchemes:
+    mtlsAuth:
+      type: X509

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_httpapikey.json
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_httpapikey.json
@@ -1,0 +1,39 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "API Key Connection Auth API",
+    "version": "1.0.0",
+    "description": "Minimal webhook API whose outbound calls to the provider are authenticated via httpApiKey, used to verify ConnectionAuthExtractor end-to-end generation."
+  },
+  "x-ballerina-event-identifier": {
+    "type": "body",
+    "path": "event"
+  },
+  "channels": {
+    "leads": {
+      "description": "Lead lifecycle events.",
+      "subscribe": {
+        "message": {
+          "x-ballerina-event-type": "lead_created",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "leadId": { "type": "string" }
+            },
+            "required": ["event", "leadId"]
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "httpApiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_oauth2_authcode.json
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_oauth2_authcode.json
@@ -1,0 +1,47 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "OAuth2 Authorization Code Connection Auth API",
+    "version": "1.0.0",
+    "description": "Minimal webhook API whose outbound calls to the provider are authenticated via oauth2 authorizationCode, used to verify ConnectionAuthExtractor end-to-end generation."
+  },
+  "x-ballerina-event-identifier": {
+    "type": "body",
+    "path": "event"
+  },
+  "channels": {
+    "calendarEvents": {
+      "description": "Calendar change notifications.",
+      "subscribe": {
+        "message": {
+          "x-ballerina-event-type": "calendar_event_changed",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "id": { "type": "string" }
+            },
+            "required": ["event", "id"]
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "googleOAuth": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/auth",
+            "tokenUrl": "https://oauth2.googleapis.com/token",
+            "refreshUrl": "https://oauth2.googleapis.com/token",
+            "scopes": {
+              "https://www.googleapis.com/auth/calendar": "Full access to Calendar"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_oauth2_clientcreds.json
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_oauth2_clientcreds.json
@@ -1,0 +1,45 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "OAuth2 Client Credentials Connection Auth API",
+    "version": "1.0.0",
+    "description": "Minimal webhook API whose outbound calls to the provider are authenticated via oauth2 clientCredentials, used to verify ConnectionAuthExtractor end-to-end generation."
+  },
+  "x-ballerina-event-identifier": {
+    "type": "body",
+    "path": "event"
+  },
+  "channels": {
+    "orders": {
+      "description": "Order lifecycle events.",
+      "subscribe": {
+        "message": {
+          "x-ballerina-event-type": "order_created",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "orderId": { "type": "string" }
+            },
+            "required": ["event", "orderId"]
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "clientCredentialsAuth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://api.example.com/oauth/token",
+            "scopes": {
+              "orders:read": "Read order data"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_userpassword.json
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_userpassword.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Username/Password Connection Auth API",
+    "version": "1.0.0",
+    "description": "Minimal webhook API whose outbound calls to the provider are authenticated via userPassword, used to verify ConnectionAuthExtractor end-to-end generation."
+  },
+  "x-ballerina-event-identifier": {
+    "type": "body",
+    "path": "event"
+  },
+  "channels": {
+    "leads": {
+      "description": "Lead lifecycle events.",
+      "subscribe": {
+        "message": {
+          "x-ballerina-event-type": "lead_created",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "leadId": { "type": "string" }
+            },
+            "required": ["event", "leadId"]
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "userPassword"
+      }
+    }
+  }
+}

--- a/asyncapi-generator/src/test/resources/specs/connection_auth_x509.json
+++ b/asyncapi-generator/src/test/resources/specs/connection_auth_x509.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Mutual TLS Connection Auth API",
+    "version": "1.0.0",
+    "description": "Minimal webhook API whose outbound calls to the provider are authenticated via X509 mutual TLS, used to verify ConnectionAuthExtractor end-to-end generation."
+  },
+  "x-ballerina-event-identifier": {
+    "type": "body",
+    "path": "event"
+  },
+  "channels": {
+    "leads": {
+      "description": "Lead lifecycle events.",
+      "subscribe": {
+        "message": {
+          "x-ballerina-event-type": "lead_created",
+          "payload": {
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "leadId": { "type": "string" }
+            },
+            "required": ["event", "leadId"]
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "mtlsAuth": {
+        "type": "X509"
+      }
+    }
+  }
+}

--- a/asyncapi-generator/src/test/resources/testng.xml
+++ b/asyncapi-generator/src/test/resources/testng.xml
@@ -19,6 +19,7 @@
             <class name="io.ballerina.asyncapi.generator.http.extractor.ServiceTypeExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.ConnectionAuthExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.SchemaExtractorTest"/>
+            <class name="io.ballerina.asyncapi.generator.http.node.GenerateListenerConfigNodeTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ListenerGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.DispatcherGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ServiceTypesGeneratorTest"/>

--- a/asyncapi-generator/src/test/resources/testng.xml
+++ b/asyncapi-generator/src/test/resources/testng.xml
@@ -17,6 +17,7 @@
             <class name="io.ballerina.asyncapi.generator.http.HttpCodeGeneratorIntegrationTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.EventIdentifierExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.ServiceTypeExtractorTest"/>
+            <class name="io.ballerina.asyncapi.generator.http.extractor.ConnectionAuthExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.SchemaExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ListenerGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.DispatcherGeneratorTest"/>


### PR DESCRIPTION
## Purpose
Triggers that call back into the provider's own API (e.g. `google.calendar` registering a webhook subscription) need OAuth2, username/password, API key, or mutual-TLS credentials to do that. Today every trigger hand-writes that `ListenerConfig` credential boilerplate from scratch, even though the pattern repeats across most triggers — the generator has no way to produce it.

Resolves https://github.com/ballerina-platform/ballerina-library/issues/8925, https://github.com/ballerina-platform/ballerina-library/issues/5000

## Goals
Extend the generator so that, when an AsyncAPI spec declares a standard `components.securitySchemes` entry (`oauth2` authorizationCode/clientCredentials, `userPassword`, `httpApiKey`, or `X509`), the corresponding credential fields are generated automatically into the trigger's `ListenerConfig`. No new custom syntax is introduced — this consumes a construct AsyncAPI already defines.

## Approach
- New `ConnectionAuthExtractor` reads `components.securitySchemes` via the existing `asyncapi-core` parsed model (no new spec-parsing code needed — it already parsed this section). Matches `userPassword`/`httpApiKey`/`X509` directly, or `oauth2` by inspecting `flows.authorizationCode`/`flows.clientCredentials`. A recognized-but-unsupported shape (e.g. `oauth2` declaring only `implicit`, or a single scheme declaring both supported flows at once) fails loudly with a `GeneratorException` rather than silently generating an incomplete or ambiguous trigger. Multiple recognized scheme entries in the same spec are rejected the same way — which one the trigger should use is genuinely ambiguous.
- `GenerateListenerConfigNode` (already responsible for the `ListenerConfig` record) appends the matching field group per scheme/flow — `clientId`/`clientSecret`/`refreshUrl`/`refreshToken` for `authorizationCode`, `clientId`/`clientSecret`/`tokenUrl` for `clientCredentials`, `username`/`password` for `userPassword`, an `apiKeyValue` field for `httpApiKey`, and a `cert`/`keyConfig` union pair for `X509`.
- The provider's token/refresh URL is generated as a field **defaulted to the spec's value**, not a hardcoded constant — AsyncAPI's `OAuthFlow` object has no way to mark a URL as varying per deployment (unlike `servers`, which has variables), so a constant would silently break multi-tenant providers with no way to override it. This also matches how the existing hand-written triggers already shape this config (verified by diffing generated output against the real `google.calendar`/`salesforce` `ListenerConfig`). The URL is escaped before being embedded in the generated string literal, so a `"` in the URL can't produce malformed generated source.
- Connection-auth field names are checked against webhook-DSL-derived config fields before being appended, failing loudly on a collision instead of generating a `ListenerConfig` with duplicate fields.
- Scope is deliberately limited to credential field generation only — no `http:Client` construction or business logic is generated, since AsyncAPI has no way to describe the destination REST API call itself (that's OpenAPI's domain). This was a scope decision made and confirmed during design, not a partial implementation.

## User stories
As a trigger author, when my AsyncAPI spec declares a standard `oauth2`, `userPassword`, `httpApiKey`, or `X509` security scheme, the generated trigger's `ListenerConfig` includes the credential fields I need to authenticate outbound calls to the provider, without me hand-writing them.

## Release note
The AsyncAPI-to-Ballerina HTTP trigger generator now generates outbound API authentication fields (OAuth2 authorization-code, OAuth2 client-credentials, username/password, HTTP API key, and X.509/mutual-TLS) into a trigger's `ListenerConfig`, derived from the spec's standard `components.securitySchemes` block.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  - `ConnectionAuthExtractorTest` (19 tests): every supported scheme/flow combination, no `components`/no `securitySchemes`/an unrelated scheme type, `httpApiKey` header/query/cookie placement plus its missing-name and invalid-`in` error paths, a single `oauth2` scheme declaring both flows at once, missing `refreshUrl`, a malformed `tokenUrl`, an unsupported flow (`implicit`-only), and multiple recognized scheme entries in one spec.
  - `GenerateListenerConfigNodeTest` (12 tests): the generated field/doc-comment shape for every supported type, field-name collisions with webhook-DSL config fields, and URL escaping for a `tokenUrl`/`refreshUrl` containing a literal `"`.
- Integration tests
  - `HttpCodeGeneratorIntegrationTest`: one full-pipeline generation per supported auth type/flow (asserting the right fields and spec-derived defaults appear in `data_types.bal`), a crypto-import regression check for `X509`, and a regression test confirming a spec with no `securitySchemes` generates unchanged output.
  - Full module suite: 374/374 passing. Checkstyle: clean.

## Samples
N/A

## Related PRs
None currently open.

## Migrations (if applicable)
N/A

## Test environment
- JDK: Temurin 21.0.2 (build/runtime), Checkstyle ruleset targets JDK 17
- OS: Windows 11 Pro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add outbound authentication field generation from AsyncAPI `components.securitySchemes`.
- Support OAuth2, username/password, HTTP API key, and X.509 authentication schemes.
- Validate unsupported, ambiguous, incomplete, and conflicting authentication configurations.
- Generate escaped URL defaults and conditional X.509 imports.
- Update listener and data type generation APIs for connection authentication.
- Add unit and integration coverage for supported schemes, validation, collisions, escaping, imports, and unchanged output without security schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->