### PR TITLE
Support primitive and zero-parameter remote functions in WS spec generation

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/Constants.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/Constants.java
@@ -136,6 +136,9 @@ public class Constants {
             + "empty";
     public static final String NO_TYPE_IN_STREAM = "ERROR: No type present in stream";
     public static final String NO_SERVICE_CLASS = "ERROR: No service class present";
+    public static final String UNSUPPORTED_PARAMETER_TYPE = "ERROR: Could not determine a message payload for "
+            + "remote function '%s' - its parameter type is not currently supported for AsyncAPI generation "
+            + "(expected a record, class, or primitive type)";
     public static final String UNION_STREAMING_SIMPLE_RPC_ERROR = "ERROR: Response server streaming types cannot be "
             + "union with simple rpc types";
     public static final String PATH_PARAM_DASH_CONTAIN_ERROR = "ERROR: Path parameter contains an invalid"

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
@@ -280,9 +280,7 @@ public class AsyncApiRemoteMapper {
                             BalAsyncApi30MessageImpl componentMessage;
                             if (requiredParameterNode == null) {
                                 if (!remoteFunctionNode.functionSignature().parameters().isEmpty()) {
-                                    // Has a parameter, but its type is none of the shapes findMessageParameter
-                                    // recognizes (e.g. an array or map) - fail loudly rather than silently
-                                    // dropping the function, per #7669.
+                                    // Unsupported parameter type - fail loudly instead of silently dropping it.
                                     throw new NoSuchElementException(
                                             String.format(UNSUPPORTED_PARAMETER_TYPE, functionName));
                                 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiRemoteMapper.java
@@ -29,6 +29,7 @@ import io.apicurio.datamodels.models.asyncapi.v30.AsyncApi30OperationsImpl;
 import io.apicurio.datamodels.models.asyncapi.v30.AsyncApi30ReferenceImpl;
 import io.apicurio.datamodels.models.asyncapi.v30.AsyncApi30Schema;
 import io.ballerina.asyncapi.generator.ws.asyncspec.model.BalAsyncApi30MessageImpl;
+import io.ballerina.asyncapi.generator.ws.asyncspec.model.BalAsyncApi30SchemaImpl;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
@@ -66,6 +67,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.ANNOTATION_ATTR_DISPATCHER_VALUE;
+import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.AsyncAPIType;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.CAMEL_CASE_PATTERN;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.CHANNELS_REFERENCE;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.DISPATCHER_CONFIG_ANNOTATION;
@@ -88,6 +90,7 @@ import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.ON_PONG;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.ON_TEXT_MESSAGE;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.REMOTE_DESCRIPTION;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.RETURN;
+import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.UNSUPPORTED_PARAMETER_TYPE;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.WEBSOCKET;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_PATH;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_PATH_FRAME_TYPE;
@@ -95,6 +98,7 @@ import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_TYPE_BODY;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.Constants.X_BALLERINA_WS_CLOSE_FRAME_VALUE_CLOSE;
+import static io.ballerina.asyncapi.generator.ws.asyncspec.utils.ConverterCommonUtils.getAsyncApiSchema;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.utils.ConverterCommonUtils.getServiceClassName;
 import static io.ballerina.asyncapi.generator.ws.asyncspec.utils.ConverterCommonUtils.unescapeIdentifier;
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.QUALIFIED_NAME_REFERENCE;
@@ -267,88 +271,120 @@ public class AsyncApiRemoteMapper {
                                     remoteFunctionNode.metadata().map(MetadataNode::annotations);
                             Optional<String> dispatcherTypeOverride =
                                     annotationNodes.flatMap(this::getDispatcherTypeFromAnnotation);
-                            RequiredParameterNode requiredParameterNode =
-                                    findCustomTypeParameter(remoteFunctionNode);
-                            if (requiredParameterNode != null) {
-                                String remoteRequestTypeName = dispatcherTypeOverride.orElseGet(() ->
-                                        unescapeIdentifier(resolveParameterTypeName(requiredParameterNode)));
+                            FunctionSymbol remoteFunctionSymbol = (FunctionSymbol) semanticModel.
+                                    symbol(remoteFunctionNode).get();
+                            Map<String, String> remoteDocs = getRemoteDocumentation(remoteFunctionSymbol);
+
+                            RequiredParameterNode requiredParameterNode = findMessageParameter(remoteFunctionNode);
+                            String remoteRequestTypeName;
+                            BalAsyncApi30MessageImpl componentMessage;
+                            if (requiredParameterNode == null) {
+                                if (!remoteFunctionNode.functionSignature().parameters().isEmpty()) {
+                                    // Has a parameter, but its type is none of the shapes findMessageParameter
+                                    // recognizes (e.g. an array or map) - fail loudly rather than silently
+                                    // dropping the function, per #7669.
+                                    throw new NoSuchElementException(
+                                            String.format(UNSUPPORTED_PARAMETER_TYPE, functionName));
+                                }
+                                // No parameters at all: a valid dispatch target with no request payload
+                                // beyond the dispatcher key value itself (e.g. onSubscription() in #7669).
+                                remoteRequestTypeName = dispatcherTypeOverride.orElseGet(() ->
+                                        functionName.substring(2));
+                                BalAsyncApi30SchemaImpl emptySchema = getAsyncApiSchema(AsyncAPIType.OBJECT
+                                        .toString());
+                                componentMessage = responseMapper.extractInlineMessageSchema(
+                                        publishMessage, remoteRequestTypeName, emptySchema, null);
+                            } else {
                                 String paramName = requiredParameterNode.paramName().get().toString().trim();
                                 Node parameterTypeNode = requiredParameterNode.typeName();
-                                TypeSymbol remoteFunctionNameTypeSymbol = (TypeSymbol) semanticModel.
-                                        symbol(parameterTypeNode).orElseThrow();
-                                TypeReferenceTypeSymbol typeRef =
-                                        (TypeReferenceTypeSymbol) remoteFunctionNameTypeSymbol;
-                                TypeSymbol type = typeRef.typeDescriptor();
-                                if (type.typeKind().equals(TypeDescKind.RECORD)
-                                        || (type.typeKind().equals(TypeDescKind.INTERSECTION)
-                                        && componentMapper.excludeReadonlyIfPresent(type).typeKind()
-                                        .equals(TypeDescKind.RECORD))) {
-                                    FunctionSymbol remoteFunctionSymbol = (FunctionSymbol) semanticModel.
-                                            symbol(remoteFunctionNode).get();
-                                    Map<String, String> remoteDocs = getRemoteDocumentation(remoteFunctionSymbol);
-
-                                    String paramDescription = null;
-                                    if (remoteDocs.containsKey(paramName)) {
-                                        paramDescription = remoteDocs.get(paramName);
-                                        remoteDocs.remove(paramName);
-                                    }
-                                    BalAsyncApi30MessageImpl componentMessage = responseMapper.
-                                            extractMessageSchemaReference(publishMessage, remoteRequestTypeName,
-                                                    remoteFunctionNameTypeSymbol, dispatcherValue, paramDescription);
-                                    if (remoteDocs.containsKey(REMOTE_DESCRIPTION)) {
-                                        componentMessage.setDescription(remoteDocs.get(REMOTE_DESCRIPTION));
-                                        remoteDocs.remove(REMOTE_DESCRIPTION);
-                                    }
-                                    if (!functionName.endsWith(ERROR)) {
-                                        ReturnTypeDescriptorNode customErrorReturnType = null;
-                                        if (onErrorReturnTypes.containsKey(functionName + ERROR)) {
-                                            customErrorReturnType = onErrorReturnTypes.get(functionName + ERROR);
-                                        } else if (onErrorReturnTypes.containsKey(ON_ERROR)) {
-                                            customErrorReturnType = onErrorReturnTypes.get(ON_ERROR);
-                                        }
-                                        if (Objects.nonNull(customErrorReturnType)) {
-                                            responseMapper.createResponse(subscribeMessage, componentMessage,
-                                                    customErrorReturnType.type(), null, FALSE, null);
-                                        }
-                                    }
-                                    Optional<ReturnTypeDescriptorNode> optionalRemoteReturnNode = remoteFunctionNode.
-                                            functionSignature().returnTypeDesc();
-                                    if (optionalRemoteReturnNode.isPresent()) {
-                                        Node remoteReturnType = optionalRemoteReturnNode.get().type();
-                                        String returnDescription = null;
-                                        if (remoteDocs.containsKey(RETURN)) {
-                                            returnDescription = remoteDocs.get(RETURN);
-                                            remoteDocs.remove(RETURN);
-                                        }
-                                        responseMapper.createResponse(subscribeMessage, componentMessage,
-                                                remoteReturnType, returnDescription, FALSE, null);
-                                    }
-                                    components.addMessage(remoteRequestTypeName, componentMessage);
-
-                                    // Register request message on channel and create send operation
-                                    BalAsyncApi30MessageImpl channelMsgRef = new BalAsyncApi30MessageImpl();
-                                    channelMsgRef.setParent(channelItem);
-                                    channelMsgRef.set$ref(MESSAGE_REFERENCE + remoteRequestTypeName);
-                                    channelItem.addMessage(remoteRequestTypeName, channelMsgRef);
-
-                                    AsyncApi30OperationImpl sendOp =
-                                            (AsyncApi30OperationImpl) operations.createOperation();
-                                    sendOp.setAction("send");
-                                    AsyncApi30ReferenceImpl channelRef =
-                                            (AsyncApi30ReferenceImpl) sendOp.createReference();
-                                    channelRef.set$ref(CHANNELS_REFERENCE + channelKey);
-                                    sendOp.setChannel(channelRef);
-                                    AsyncApi30ReferenceImpl sendMsgRef =
-                                            (AsyncApi30ReferenceImpl) sendOp.createReference();
-                                    sendMsgRef.set$ref(CHANNELS_REFERENCE + channelKey
-                                            + "/messages/" + remoteRequestTypeName);
-                                    sendOp.addMessage(sendMsgRef);
-                                    operations.addItem("send" + remoteRequestTypeName, sendOp);
+                                String paramDescription = null;
+                                if (remoteDocs.containsKey(paramName)) {
+                                    paramDescription = remoteDocs.get(paramName);
+                                    remoteDocs.remove(paramName);
+                                }
+                                if (isPrimitiveTypeDesc(parameterTypeNode.kind())) {
+                                    // A primitive-typed parameter (e.g. `string`) has no named type to
+                                    // derive a message name from, unlike a record/class reference - fall
+                                    // back to the function name, same as the zero-parameter case above.
+                                    remoteRequestTypeName = dispatcherTypeOverride.orElseGet(() ->
+                                            functionName.substring(2));
+                                    BalAsyncApi30SchemaImpl primitiveSchema =
+                                            getAsyncApiSchema(parameterTypeNode.kind());
+                                    componentMessage = responseMapper.extractInlineMessageSchema(
+                                            publishMessage, remoteRequestTypeName, primitiveSchema,
+                                            paramDescription);
                                 } else {
-                                    throw new NoSuchElementException(String.format(FUNCTION_SIGNATURE_WRONG_TYPE,
-                                            remoteRequestTypeName, type.typeKind().getName()));
+                                    remoteRequestTypeName = dispatcherTypeOverride.orElseGet(() ->
+                                            unescapeIdentifier(resolveParameterTypeName(requiredParameterNode)));
+                                    TypeSymbol remoteFunctionNameTypeSymbol = (TypeSymbol) semanticModel.
+                                            symbol(parameterTypeNode).orElseThrow();
+                                    TypeReferenceTypeSymbol typeRef =
+                                            (TypeReferenceTypeSymbol) remoteFunctionNameTypeSymbol;
+                                    TypeSymbol type = typeRef.typeDescriptor();
+                                    if (type.typeKind().equals(TypeDescKind.RECORD)
+                                            || (type.typeKind().equals(TypeDescKind.INTERSECTION)
+                                            && componentMapper.excludeReadonlyIfPresent(type).typeKind()
+                                            .equals(TypeDescKind.RECORD))) {
+                                        componentMessage = responseMapper.extractMessageSchemaReference(
+                                                publishMessage, remoteRequestTypeName, remoteFunctionNameTypeSymbol,
+                                                dispatcherValue, paramDescription);
+                                    } else {
+                                        throw new NoSuchElementException(String.format(
+                                                FUNCTION_SIGNATURE_WRONG_TYPE, remoteRequestTypeName,
+                                                type.typeKind().getName()));
+                                    }
                                 }
                             }
+
+                            if (remoteDocs.containsKey(REMOTE_DESCRIPTION)) {
+                                componentMessage.setDescription(remoteDocs.get(REMOTE_DESCRIPTION));
+                                remoteDocs.remove(REMOTE_DESCRIPTION);
+                            }
+                            if (!functionName.endsWith(ERROR)) {
+                                ReturnTypeDescriptorNode customErrorReturnType = null;
+                                if (onErrorReturnTypes.containsKey(functionName + ERROR)) {
+                                    customErrorReturnType = onErrorReturnTypes.get(functionName + ERROR);
+                                } else if (onErrorReturnTypes.containsKey(ON_ERROR)) {
+                                    customErrorReturnType = onErrorReturnTypes.get(ON_ERROR);
+                                }
+                                if (Objects.nonNull(customErrorReturnType)) {
+                                    responseMapper.createResponse(subscribeMessage, componentMessage,
+                                            customErrorReturnType.type(), null, FALSE, null);
+                                }
+                            }
+                            Optional<ReturnTypeDescriptorNode> optionalRemoteReturnNode = remoteFunctionNode.
+                                    functionSignature().returnTypeDesc();
+                            if (optionalRemoteReturnNode.isPresent()) {
+                                Node remoteReturnType = optionalRemoteReturnNode.get().type();
+                                String returnDescription = null;
+                                if (remoteDocs.containsKey(RETURN)) {
+                                    returnDescription = remoteDocs.get(RETURN);
+                                    remoteDocs.remove(RETURN);
+                                }
+                                responseMapper.createResponse(subscribeMessage, componentMessage,
+                                        remoteReturnType, returnDescription, FALSE, null);
+                            }
+                            components.addMessage(remoteRequestTypeName, componentMessage);
+
+                            // Register request message on channel and create send operation
+                            BalAsyncApi30MessageImpl channelMsgRef = new BalAsyncApi30MessageImpl();
+                            channelMsgRef.setParent(channelItem);
+                            channelMsgRef.set$ref(MESSAGE_REFERENCE + remoteRequestTypeName);
+                            channelItem.addMessage(remoteRequestTypeName, channelMsgRef);
+
+                            AsyncApi30OperationImpl sendOp =
+                                    (AsyncApi30OperationImpl) operations.createOperation();
+                            sendOp.setAction("send");
+                            AsyncApi30ReferenceImpl channelRef =
+                                    (AsyncApi30ReferenceImpl) sendOp.createReference();
+                            channelRef.set$ref(CHANNELS_REFERENCE + channelKey);
+                            sendOp.setChannel(channelRef);
+                            AsyncApi30ReferenceImpl sendMsgRef =
+                                    (AsyncApi30ReferenceImpl) sendOp.createReference();
+                            sendMsgRef.set$ref(CHANNELS_REFERENCE + channelKey
+                                    + "/messages/" + remoteRequestTypeName);
+                            sendOp.addMessage(sendMsgRef);
+                            operations.addItem("send" + remoteRequestTypeName, sendOp);
                         }
                     } else {
                         throw new NoSuchElementException(FUNCTION_WRONG_NAME);
@@ -448,22 +484,29 @@ public class AsyncApiRemoteMapper {
     }
 
     /**
-     * Finds the remote function's data parameter - the first required parameter whose type is a
-     * named reference to a custom (record) type. The function's own name plays no part in this;
-     * only the parameter's actual declared type determines what gets generated.
+     * Finds the remote function's data parameter - the first required parameter whose type is
+     * either a named reference to a custom (record or class) type, or a primitive scalar type
+     * (see {@link #isPrimitiveTypeDesc}). The function's own name plays no part in this; only the
+     * parameter's actual declared type determines what gets generated.
+     *
+     * <p>Returning {@code null} here does not by itself mean the function is skipped - callers
+     * distinguish "no parameters at all" (a valid, payload-less remote function - see #7669) from
+     * "has a parameter, but its type isn't one of the shapes above" (genuinely unsupported, and
+     * reported rather than silently dropped).
      *
      * @param remoteFunctionNode the remote function definition node
-     * @return the resolved parameter node, or {@code null} if none of the required parameters
-     *         reference a named custom type
+     * @return the resolved parameter node, or {@code null} if there are no required parameters,
+     *         or none of them reference a named custom type or a primitive scalar type
      */
-    private RequiredParameterNode findCustomTypeParameter(FunctionDefinitionNode remoteFunctionNode) {
+    private RequiredParameterNode findMessageParameter(FunctionDefinitionNode remoteFunctionNode) {
         SeparatedNodeList<ParameterNode> remoteParameters = remoteFunctionNode.functionSignature().parameters();
         for (ParameterNode remoteParameterNode : remoteParameters) {
             if (remoteParameterNode.kind() == SyntaxKind.REQUIRED_PARAM) {
                 RequiredParameterNode requiredParameterNode = (RequiredParameterNode) remoteParameterNode;
                 Node parameterTypeNode = requiredParameterNode.typeName();
                 if (parameterTypeNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE
-                        || parameterTypeNode.kind() == QUALIFIED_NAME_REFERENCE) {
+                        || parameterTypeNode.kind() == QUALIFIED_NAME_REFERENCE
+                        || isPrimitiveTypeDesc(parameterTypeNode.kind())) {
                     return requiredParameterNode;
                 }
             }
@@ -472,7 +515,8 @@ public class AsyncApiRemoteMapper {
     }
 
     /**
-     * Reads the actual type name off a parameter resolved by {@link #findCustomTypeParameter}.
+     * Reads the actual type name off a parameter resolved by {@link #findMessageParameter} whose
+     * type is a named record/class reference (not a primitive - see {@link #isPrimitiveTypeDesc}).
      *
      * @param requiredParameterNode the resolved parameter node
      * @return the parameter's declared type name
@@ -483,6 +527,25 @@ public class AsyncApiRemoteMapper {
             return ((SimpleNameReferenceNode) parameterTypeNode).name().toString().trim();
         }
         return ((QualifiedNameReferenceNode) parameterTypeNode).identifier().text();
+    }
+
+    /**
+     * True for the built-in scalar type-descriptor kinds that {@link ConverterCommonUtils#
+     * getAsyncApiSchema(SyntaxKind)} can turn directly into an inline AsyncAPI schema - the same
+     * set already supported on the return-type side (see {@code AsyncApiResponseMapper#
+     * createResponse}). Deliberately narrower than every kind that method accepts (e.g. excludes
+     * {@code ARRAY_TYPE_DESC}/{@code MAP_TYPE_DESC}): this only needs to cover what a remote
+     * function *parameter* can validly be shaped as for #7669, not every return-type shape.
+     *
+     * @param kind the parameter's type-descriptor syntax kind
+     * @return {@code true} if it's a supported primitive scalar type
+     */
+    private static boolean isPrimitiveTypeDesc(SyntaxKind kind) {
+        return switch (kind) {
+            case SyntaxKind.STRING_TYPE_DESC, SyntaxKind.INT_TYPE_DESC, SyntaxKind.BOOLEAN_TYPE_DESC,
+                    SyntaxKind.DECIMAL_TYPE_DESC, SyntaxKind.FLOAT_TYPE_DESC -> true;
+            default -> false;
+        };
     }
 
     private Optional<String> getDispatcherTypeFromAnnotation(NodeList<AnnotationNode> annotationNodes) {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiResponseMapper.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/ws/asyncspec/mapper/AsyncApiResponseMapper.java
@@ -291,6 +291,43 @@ public class AsyncApiResponseMapper {
         return componentMessage;
     }
 
+    /**
+     * Creates a message entry with an inline (non-{@code $ref}) schema for a request payload
+     * that isn't a named record type - a primitive-typed parameter, or a zero-parameter remote
+     * function with no payload at all. Unlike {@link #extractMessageSchemaReference}, no
+     * component schema is registered in {@code components.schemas} and no discriminator field is
+     * injected, since there's no record to carry one: the schema is embedded directly in the
+     * message rather than referenced.
+     *
+     * @param message          channel-level message to add oneOf reference to
+     * @param typeName         the message name (from a dispatcher override annotation, or derived
+     *                         from the remote function's name when there's no parameter type name
+     *                         to use)
+     * @param schema           the inline schema describing the payload (e.g. {@code {type: string}}
+     *                         for a primitive parameter, or an empty object schema for no payload)
+     * @param paramDescription optional description for the payload node
+     * @return the component-level message with the payload set
+     */
+    public BalAsyncApi30MessageImpl extractInlineMessageSchema(BalAsyncApi30MessageImpl message, String typeName,
+                                                                BalAsyncApi30SchemaImpl schema,
+                                                                String paramDescription) {
+        BalAsyncApi30MessageImpl messageType = new BalAsyncApi30MessageImpl();
+
+        ObjectMapper objectMapper = callObjectMapper();
+        ObjectNode schemaNode = objectMapper.valueToTree(schema);
+        if (paramDescription != null) {
+            schemaNode.put(DESCRIPTION, paramDescription);
+        }
+
+        BalAsyncApi30MessageImpl componentMessage = new BalAsyncApi30MessageImpl();
+        componentMessage.setParent(components);
+        componentMessage.addExtension(PAYLOAD, schemaNode);
+
+        messageType.set$ref(MESSAGE_REFERENCE + ConverterCommonUtils.unescapeIdentifier(typeName));
+        setSchemasForChannelsAsOneOfSchema(message, messageType);
+        return componentMessage;
+    }
+
     private void setResponseOfRequest(BalAsyncApi30MessageImpl subscribeMessage,
                                       BalAsyncApi30MessageImpl componentMessage, String responseType,
                                       String returnDescription, ObjectMapper objMapper,

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/ws/asyncspec/BallerinaToAsyncApiGeneratorTest.java
@@ -941,4 +941,133 @@ class BallerinaToAsyncApiGeneratorTest {
         String yaml = readGeneratedYaml();
         Assert.assertTrue(yaml.contains("9090"), "listener port must appear in server definition");
     }
+
+    // Regression fixture for #7669, reproduced verbatim from the issue report. Exercises all
+    // three parameter/payload shapes in one service: a primitive-typed parameter
+    // (onConnectionInit(string)), a zero-parameter remote function (onSubscription()), and the
+    // reserved onMessage lifecycle hook, which must still be excluded from the generated spec.
+    private static final String BAL_ISSUE_7669 =
+            "import ballerina/websocket;\n\n"
+            + "@websocket:ServiceConfig {\n"
+            + "    dispatcherKey: \"event\"\n"
+            + "}\n"
+            + "service /websockets on new websocket:Listener(9090) {\n"
+            + "    resource function get .() returns MyGqlSubService {\n"
+            + "        return new MyGqlSubService();\n"
+            + "    }\n"
+            + "}\n\n"
+            + "service class MyGqlSubService {\n"
+            + "    *websocket:Service;\n\n"
+            + "    remote function onConnectionInit(string chatMessage) returns ConnectionAck|error {\n"
+            + "        ConnectionAck connAck = { event: \"connection_ack\", payload: \"{}\" };\n"
+            + "        return connAck;\n"
+            + "    }\n\n"
+            + "    remote function onSubscription() returns stream<Next|Complete> {\n"
+            + "        Next[] next = [\n"
+            + "            { id: \"1\", event: \"data\", payload: \"{}\" },\n"
+            + "            { id: \"2\", event: \"data\", payload: \"{}\" },\n"
+            + "            { id: \"3\", event: \"data\", payload: \"{}\" }\n"
+            + "        ];\n"
+            + "        return next.toStream();\n"
+            + "    }\n\n"
+            + "    remote function onMessage(websocket:Caller caller, string chatMessage) returns error? {\n"
+            + "        return caller->close(4408, \"Connection initialisation timeout\");\n"
+            + "    }\n"
+            + "}\n\n"
+            + "type Next record {|\n"
+            + "    string id;\n"
+            + "    string event;\n"
+            + "    string payload;\n"
+            + "|};\n\n"
+            + "type Complete record {|\n"
+            + "    string id;\n"
+            + "    string event;\n"
+            + "|};\n\n"
+            + "type ConnectionAck record {|\n"
+            + "    string event;\n"
+            + "    string payload;\n"
+            + "|};\n";
+
+    @Test
+    void testIssue7669_primitiveAndZeroParamRemoteFunctionsAppearInSpec() throws IOException {
+        List<AsyncApiConverterDiagnostic> diagnostics = run(BAL_ISSUE_7669);
+        Assert.assertTrue(diagnostics.isEmpty(),
+                "generator must produce no diagnostics for onConnectionInit's primitive parameter "
+                        + "or onSubscription's zero parameters. Diagnostics: " + diagnostics);
+        String yaml = readGeneratedYaml();
+
+        // onConnectionInit(string chatMessage): primitive-typed parameter -> inline string schema,
+        // message name falls back to the function name (no record type to derive it from).
+        Assert.assertTrue(yaml.contains("sendConnectionInit"),
+                "a send operation must be generated for onConnectionInit despite its primitive parameter");
+        Assert.assertFalse(yaml.contains("#/components/schemas/ConnectionInit"),
+                "ConnectionInit's payload must be an inline schema, not a $ref to a component schema "
+                        + "(a primitive parameter has no named type to define one from)");
+
+        // onSubscription(): zero parameters -> inline empty-object schema, same fallback naming.
+        Assert.assertTrue(yaml.contains("sendSubscription"),
+                "a send operation must be generated for onSubscription despite having no parameters");
+
+        // Return types must still be processed for both, using the existing (already-working)
+        // return-type machinery -- onConnectionInit's ConnectionAck|error and onSubscription's
+        // stream<Next|Complete>.
+        Assert.assertTrue(yaml.contains("receiveConnectionAck"),
+                "onConnectionInit's ConnectionAck return type must still be processed");
+        Assert.assertTrue(yaml.contains("receiveNext") && yaml.contains("receiveComplete"),
+                "onSubscription's stream<Next|Complete> return type must still be processed, split per "
+                        + "union member");
+
+        // onMessage(websocket:Caller, string): the reserved WS lifecycle hook -- must remain
+        // excluded, same as before this fix. Its parameter shape (Caller + string) would otherwise
+        // now be primitive-eligible, so this specifically guards against the reserved-name check
+        // being bypassed by the broadened parameter handling.
+        Assert.assertFalse(yaml.contains("sendMessage") || yaml.contains("receiveMessage"),
+                "onMessage must remain excluded as a reserved WebSocket lifecycle hook, not a "
+                        + "dispatched application message");
+    }
+
+    // Regression fixture isolating stream<Union> return-type support from the zero-parameter
+    // fix above: a normal record-typed parameter (already supported) paired with a stream return
+    // type, the same return shape onSubscription() uses in #7669.
+    private static final String BAL_STREAM_RETURN_CHECK =
+            "import ballerina/websocket;\n\n"
+            + "public type ChatMessage record {\n"
+            + "    string event;\n"
+            + "    string content;\n"
+            + "};\n\n"
+            + "public type Next record {|\n"
+            + "    string id;\n"
+            + "|};\n\n"
+            + "public type Complete record {|\n"
+            + "    string id;\n"
+            + "|};\n\n"
+            + "@websocket:ServiceConfig {dispatcherKey: \"event\"}\n"
+            + "service /chat on new websocket:Listener(9090) {\n"
+            + "    resource function get .() returns websocket:Service|websocket:UpgradeError {\n"
+            + "        return new ChatService();\n"
+            + "    }\n"
+            + "}\n\n"
+            + "service class ChatService {\n"
+            + "    *websocket:Service;\n"
+            + "    remote function onChatMessage(ChatMessage msg) returns stream<Next|Complete> {\n"
+            + "        Next[] next = [{id: \"1\"}];\n"
+            + "        return next.toStream();\n"
+            + "    }\n"
+            + "}\n";
+
+    @Test
+    void testStreamReturnType_generatesReceiveOperationsPerUnionMember() throws IOException {
+        List<AsyncApiConverterDiagnostic> diagnostics = run(BAL_STREAM_RETURN_CHECK);
+        Assert.assertTrue(diagnostics.isEmpty(),
+                "generator must produce no diagnostics for a stream<Union> return type. Diagnostics: "
+                        + diagnostics);
+        String yaml = readGeneratedYaml();
+
+        Assert.assertTrue(yaml.contains("sendChatMessage"),
+                "the request side (record-typed parameter) must be unaffected");
+        Assert.assertTrue(yaml.contains("receiveNext") && yaml.contains("receiveComplete"),
+                "stream<Next|Complete> must split into one receive operation per union member");
+        Assert.assertTrue(yaml.contains("x-response-type: server-streaming"),
+                "the response must be tagged as server-streaming, not a one-shot simple-rpc reply");
+    }
 }


### PR DESCRIPTION
## Purpose
The AsyncAPI generator silently drops WebSocket remote functions whose parameter is a primitive type (e.g. `string`) or that take no parameter at all — no exception, no diagnostic, they just don't appear in the generated spec. Any service using either shape generates an incomplete spec with no indication anything is missing.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/7669

## Goals
Generate a complete AsyncAPI spec for remote functions with these two parameter shapes, the same way record/class-typed parameters already work — and make any genuinely unsupported shape (e.g. an array or map parameter) fail with a clear diagnostic instead of silently vanishing.

## Approach
The mapper's parameter-shape check (`findMessageParameter`, formerly `findCustomTypeParameter`) only recognized a parameter that's a named reference to a record or class type; anything else made the whole per-function processing block a no-op. Broadened it to also accept primitive scalar types (`string`, `int`, `boolean`, `decimal`, `float`) and zero-parameter functions, routing both to a new inline-schema message builder (`AsyncApiResponseMapper#extractInlineMessageSchema`) instead of the existing `$ref`-to-a-component-schema path, since neither has a named record to define a schema for.

Message naming for these two shapes falls back to the remote function's own name (`onSubscription` → `Subscription`), since there's no parameter type name to derive it from — same `on<Type>` convention the tool already enforces elsewhere, and still overridable via the existing dispatcher-type annotation.

Return-type processing (including `stream<Union>` return types, which needed no changes — verified already working, just previously unreachable for these two shapes) and channel/operation registration were restructured to run unconditionally after the request-side message is resolved, rather than only inside the record-type branch.

## Release note
The Ballerina-to-AsyncAPI generator now correctly generates channels and operations for WebSocket remote functions with a primitive-typed parameter or no parameter, instead of silently omitting them. A parameter type that still isn't supported (e.g. an array or map) now produces a clear error instead of an incomplete spec.

## Documentation
N/A 

## Training
N/A 

## Certification
N/A 

## Marketing
N/A 

## Automation tests
- Unit tests
  - N/A — this module's coverage for this area is at the integration level (see below); no isolated unit tests added.
- Integration tests
  - `testIssue7669_primitiveAndZeroParamRemoteFunctionsAppearInSpec`: reproduces the issue's exact sample. Asserts zero diagnostics, both new send operations are generated, the primitive-typed message uses an inline schema (not a `$ref`), both return types (including the `stream<Union>` one) are still processed, and `onMessage` remains correctly excluded as a reserved lifecycle hook.
  - `testStreamReturnType_generatesReceiveOperationsPerUnionMember`: isolates `stream<Union>` return-type handling from the parameter-side fix, using a normal record-typed parameter.
  - Full module suite: 334/334 passing. Checkstyle: clean.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **No formal review performed against this document.**
- Ran FindSecurityBugs plugin and verified report? **No** — not run as part of this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **Yes** — no credentials involved; all changes are to spec-generation logic and test fixtures using fictional sample data.

## Samples
N/A 

## Migrations (if applicable)
N/A

## Test environment
- JDK: Temurin 21.0.2 (build/runtime), Checkstyle ruleset targets JDK 17
- OS: Windows 11 Pro
