### PR TITLE
Fix/webhook dispatcher ack and signature format

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatchTestGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatchTestGenerator.java
@@ -94,6 +94,7 @@ public class DispatchTestGenerator {
         }
 
         source.append(buildSendHelper());
+        source.append(buildWaitHelper());
 
         for (DispatchTestCase testCase : testCases) {
             source.append(buildTestFunction(testCase));
@@ -116,7 +117,8 @@ public class DispatchTestGenerator {
         return "import ballerina/test;\n"
                 + "import ballerina/http;\n"
                 + "import ballerina/crypto;\n"
-                + "import ballerina/io;\n\n"
+                + "import ballerina/io;\n"
+                + "import ballerina/lang.runtime;\n\n"
                 + "const string TRIGGER_TEST_SECRET = \"" + TEST_SECRET + "\";\n"
                 + "const int TRIGGER_TEST_PORT = " + TEST_PORT + ";\n"
                 + "const string TRIGGER_PAYLOAD_DIR = \"" + DEFAULT_PAYLOAD_DIR + "\";\n\n"
@@ -195,8 +197,26 @@ public class DispatchTestGenerator {
                 + "    http:Response response = check sendSignedTriggerWebhook(\""
                 + testCase.headerValue() + "\", \"" + testCase.eventIdentifier() + "\");\n"
                 + "    test:assertEquals(response.statusCode, http:STATUS_OK);\n"
-                + "    test:assertTrue(triggerFired[\"" + trackerKey + "\"] ?: false, \""
+                + "    test:assertTrue(waitForDispatch(\"" + trackerKey + "\"), \""
                 + trackerKey + " should have fired\");\n"
+                + "}\n\n";
+    }
+
+    /**
+     * Emits the {@code waitForDispatch} helper: the dispatcher acks before invoking the user's
+     * handler, so the HTTP response the test client receives does not guarantee the handler has
+     * finished running yet on the server side. Polls {@code triggerFired} briefly instead of
+     * checking it once immediately after the response returns.
+     */
+    private String buildWaitHelper() {
+        return "function waitForDispatch(string trackerKey) returns boolean {\n"
+                + "    foreach int i in 0 ..< 20 {\n"
+                + "        if triggerFired[trackerKey] ?: false {\n"
+                + "            return true;\n"
+                + "        }\n"
+                + "        runtime:sleep(0.05);\n"
+                + "    }\n"
+                + "    return false;\n"
                 + "}\n\n";
     }
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatchTestGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatchTestGenerator.java
@@ -20,6 +20,8 @@ package io.ballerina.asyncapi.generator.http.generator;
 import io.ballerina.asyncapi.generator.GeneratorException;
 import io.ballerina.asyncapi.generator.http.model.DispatchTestCase;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
+import io.ballerina.asyncapi.generator.http.utils.HeaderTemplateParser;
+import io.ballerina.asyncapi.generator.http.utils.HeaderTemplateParser.HeaderTemplate;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
@@ -41,11 +43,12 @@ import java.util.Map;
  * curated data, not synthesizable from a schema alone) to a listener started on a dedicated test
  * port, then asserts the expected remote function fired.
  *
- * <p>Signing currently supports only the simple case backing this DSL's legacy/default fallback
- * (a single HMAC digest of the raw body, hex-encoded, under the configured header name with no
- * literal prefix) -- the same scheme GitHub's spec currently resolves to. Specs using a richer
- * {@code headerFormat} (literal prefixes, {@code $config}/{@code $header} composition, multiple
- * HMAC inputs) are not yet supported by this generator and are out of scope for this pass.
+ * <p>Signing currently supports a single HMAC-SHA256 digest of the raw body, hex-encoded, spliced
+ * into the configured {@code headerFormat} (literal prefix/suffix text around a single
+ * {@code signature} placeholder, e.g. {@code "sha256=$signature"} -- the scheme GitHub's spec
+ * uses). Other algorithms/encodings, and richer {@code headerFormat}s with additional placeholders
+ * or {@code $config}/{@code $header} composition, are not yet supported by this generator and are
+ * out of scope for this pass.
  */
 public class DispatchTestGenerator {
 
@@ -136,15 +139,19 @@ public class DispatchTestGenerator {
         return sb.toString();
     }
 
-    private String buildSendHelper() {
+    private String buildSendHelper() throws GeneratorException {
         String signatureHeader = webhookAuthConfig != null && webhookAuthConfig.headerName() != null
                 ? webhookAuthConfig.headerName()
                 : "X-Hub-Signature-256";
+        String headerFormat = webhookAuthConfig != null ? webhookAuthConfig.headerFormat() : null;
+        HeaderTemplate template = HeaderTemplateParser.parse(headerFormat);
+        String signatureExpr = buildSignatureExpression(template);
         return "isolated function sendSignedTriggerWebhook(string headerValue, string eventIdentifier) "
                 + "returns http:Response|error {\n"
                 + "    byte[] body = check io:fileReadBytes(string `${TRIGGER_PAYLOAD_DIR}/${eventIdentifier}.json`);\n"
                 + "    byte[] digest = check crypto:hmacSha256(body, TRIGGER_TEST_SECRET.toBytes());\n"
-                + "    string signature = digest.toBase16();\n\n"
+                + "    string computedSignature = digest.toBase16();\n"
+                + "    string signature = " + signatureExpr + ";\n\n"
                 + "    http:Client triggerClient = check new (string `http://localhost:${TRIGGER_TEST_PORT}`);\n"
                 + "    http:Request request = new;\n"
                 + "    request.setBinaryPayload(body, contentType = \"application/json\");\n"
@@ -154,6 +161,32 @@ public class DispatchTestGenerator {
                 + "}\n\n";
     }
 
+    /**
+     * Builds a Ballerina string-template expression that splices the computed signature into the
+     * configured {@code headerFormat}, e.g. {@code headerFormat = "sha256=$signature"} becomes
+     * {@code string `sha256=${computedSignature}`}. Only the {@code signature} placeholder is
+     * substituted -- see the class-level doc for the scope of {@code headerFormat}s supported.
+     *
+     * @param template the parsed {@code headerFormat}
+     * @return a Ballerina expression, as source text, evaluating to the full header value
+     */
+    private String buildSignatureExpression(HeaderTemplate template) {
+        StringBuilder expression = new StringBuilder("string `");
+        for (int i = 0; i < template.variables().size(); i++) {
+            expression.append(escapeBacktickTemplate(template.literals().get(i)));
+            String variable = template.variables().get(i);
+            expression.append("${").append("signature".equals(variable) ? "computedSignature" : variable)
+                    .append("}");
+        }
+        expression.append(escapeBacktickTemplate(template.literals().get(template.literals().size() - 1)));
+        expression.append("`");
+        return expression.toString();
+    }
+
+    private String escapeBacktickTemplate(String value) {
+        return value.replace("\\", "\\\\").replace("`", "\\`");
+    }
+
     private String buildTestFunction(DispatchTestCase testCase) {
         String testFnName = "test" + capitalize(testCase.functionName().replaceFirst("^on", "")) + "Dispatch";
         String trackerKey = testCase.serviceTypeName() + "." + testCase.functionName();
@@ -161,7 +194,7 @@ public class DispatchTestGenerator {
                 + "function " + testFnName + "() returns error? {\n"
                 + "    http:Response response = check sendSignedTriggerWebhook(\""
                 + testCase.headerValue() + "\", \"" + testCase.eventIdentifier() + "\");\n"
-                + "    test:assertEquals(response.statusCode, http:STATUS_CREATED);\n"
+                + "    test:assertEquals(response.statusCode, http:STATUS_OK);\n"
                 + "    test:assertTrue(triggerFired[\"" + trackerKey + "\"] ?: false, \""
                 + trackerKey + " should have fired\");\n"
                 + "}\n\n";

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
@@ -144,7 +144,9 @@ public class GeneratePostResourceFunctionNode implements Generator {
                 "%s %s = check payload.cloneWithType(%s);",
                 DataTypesGenerator.GENERIC_DATA_TYPE, GenerateDispatcherServiceNode.CLONE_WITH_TYPE_VAR_NAME,
                 DataTypesGenerator.GENERIC_DATA_TYPE)));
-        statements.add(NodeParser.parseStatement("check caller->respond(http:STATUS_OK);"));
+        statements.add(NodeParser.parseStatement(
+                "http:Response ackResponse = new; ackResponse.statusCode = http:STATUS_OK;"
+                        + " check caller->respond(ackResponse);"));
         if (EventIdentifierExtractor.X_BALLERINA_EVENT_TYPE_COMPOSITE.equals(type)) {
             statements.add(NodeParser.parseStatement(String.format(
                     "error? dispatchResult = self.%s(%s, eventIdentifier, eventType);",

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
@@ -144,18 +144,20 @@ public class GeneratePostResourceFunctionNode implements Generator {
                 "%s %s = check payload.cloneWithType(%s);",
                 DataTypesGenerator.GENERIC_DATA_TYPE, GenerateDispatcherServiceNode.CLONE_WITH_TYPE_VAR_NAME,
                 DataTypesGenerator.GENERIC_DATA_TYPE)));
+        statements.add(NodeParser.parseStatement("check caller->respond(http:STATUS_OK);"));
         if (EventIdentifierExtractor.X_BALLERINA_EVENT_TYPE_COMPOSITE.equals(type)) {
             statements.add(NodeParser.parseStatement(String.format(
-                    "check self.%s(%s, eventIdentifier, eventType);",
+                    "error? dispatchResult = self.%s(%s, eventIdentifier, eventType);",
                     GenerateMatchRemoteFuncNode.DISPATCHER_MATCH_REMOTE_FUNC,
                     GenerateDispatcherServiceNode.CLONE_WITH_TYPE_VAR_NAME)));
         } else {
             statements.add(NodeParser.parseStatement(String.format(
-                    "check self.%s(%s, eventType);",
+                    "error? dispatchResult = self.%s(%s, eventType);",
                     GenerateMatchRemoteFuncNode.DISPATCHER_MATCH_REMOTE_FUNC,
                     GenerateDispatcherServiceNode.CLONE_WITH_TYPE_VAR_NAME)));
         }
-        statements.add(NodeParser.parseStatement("check caller->respond(http:STATUS_OK);"));
+        statements.add(NodeParser.parseStatement(
+                "if dispatchResult is error { log:printError(\"DISPATCH_FAILED\", dispatchResult); }"));
 
         FunctionBodyBlockNode body = createFunctionBodyBlockNode(
                 createToken(OPEN_BRACE_TOKEN), null, createNodeList(statements),

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/WebhookDSLVerificationTest.java
@@ -53,6 +53,29 @@ public class WebhookDSLVerificationTest {
     }
 
     @Test
+    public void testGithubDispatchTestSignatureFormatAndStatusCode() throws Exception {
+        // github_verification.yaml configures headerFormat: "sha256=$signature", matching the real
+        // prefix GitHub always sends. The generated tests/dispatch_test.bal must build its outgoing
+        // signature using that same prefix, and assert the status code the dispatcher actually
+        // returns (STATUS_OK) - not a bare/wrong-status signature that would never pass real
+        // verification.
+        Path tempOutputDir = generateOutputDir("github_verification.yaml");
+        Path dispatchTestFile = tempOutputDir.resolve("tests").resolve("dispatch_test.bal");
+        Assert.assertTrue(Files.exists(dispatchTestFile), "tests/dispatch_test.bal was not generated!");
+        String dispatchTestContent = Files.readString(dispatchTestFile);
+
+        Assert.assertTrue(
+                dispatchTestContent.contains("string signature = string `sha256=${computedSignature}`;"),
+                "Should splice the computed signature into the configured sha256= headerFormat prefix");
+        Assert.assertTrue(
+                dispatchTestContent.contains("http:STATUS_OK"),
+                "Should assert the status code the dispatcher actually returns");
+        Assert.assertFalse(
+                dispatchTestContent.contains("http:STATUS_CREATED"),
+                "Should not assert a status code the dispatcher never returns");
+    }
+
+    @Test
     public void testStripeWebhookVerificationDsl() throws Exception {
     String content = generateDispatcherService("stripe_verification.yaml");
     Assert.assertTrue(content.contains("request.getHeader(\"Stripe-Signature\")"),
@@ -131,7 +154,7 @@ public class WebhookDSLVerificationTest {
         "Invalid input token in webhook DSL");
     }
 
-    private String generateDispatcherService(String specFile) throws Exception {
+    private Path generateOutputDir(String specFile) throws Exception {
     Path asyncapiPath = RES_DIR.resolve(specFile);
     String yamlContent = Files.readString(asyncapiPath);
     ObjectNode specNode = (ObjectNode) YAML_MAPPER.readTree(yamlContent);
@@ -144,7 +167,11 @@ public class WebhookDSLVerificationTest {
     Files.createDirectories(tempOutputDir);
     HttpCodeGenerator generator = new HttpCodeGenerator(spec);
     generator.generate(tempOutputDir);
+    return tempOutputDir;
+    }
 
+    private String generateDispatcherService(String specFile) throws Exception {
+    Path tempOutputDir = generateOutputDir(specFile);
     Path dispatcherFile = tempOutputDir.resolve("dispatcher_service.bal");
     Assert.assertTrue(Files.exists(dispatcherFile), "dispatcher_service.bal was not generated!");
     return Files.readString(dispatcherFile);

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
@@ -94,9 +94,13 @@ public class DispatcherGeneratorTest {
         String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
                 "test_service").generate();
 
-        int ackIndex = source.indexOf("check caller->respond(http:STATUS_OK);");
+        int ackIndex = source.indexOf("ackResponse.statusCode = http:STATUS_OK;");
         int dispatchIndex = source.indexOf("error? dispatchResult =");
         Assert.assertTrue(ackIndex >= 0, "Generated source should ack with STATUS_OK");
+        Assert.assertTrue(source.contains("check caller->respond(ackResponse);"),
+                "Ack must be sent via a real http:Response with statusCode set - passing the status "
+                        + "constant directly to respond() sends it as the response body instead, and the "
+                        + "framework falls back to its default status for the method (201 for POST)");
         Assert.assertTrue(dispatchIndex >= 0,
                 "Generated source should capture the dispatch result instead of propagating it via check");
         Assert.assertTrue(ackIndex < dispatchIndex,

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
@@ -89,6 +89,25 @@ public class DispatcherGeneratorTest {
     }
 
     @Test
+    void testAckSentBeforeDispatchAndDispatchErrorsAreNotPropagated() throws GeneratorException {
+        EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
+                "test_service").generate();
+
+        int ackIndex = source.indexOf("check caller->respond(http:STATUS_OK);");
+        int dispatchIndex = source.indexOf("error? dispatchResult =");
+        Assert.assertTrue(ackIndex >= 0, "Generated source should ack with STATUS_OK");
+        Assert.assertTrue(dispatchIndex >= 0,
+                "Generated source should capture the dispatch result instead of propagating it via check");
+        Assert.assertTrue(ackIndex < dispatchIndex,
+                "The ack must be sent before dispatching to the user's handler, so a handler error can "
+                        + "never prevent the caller from receiving an acknowledgement");
+        Assert.assertFalse(source.contains("check self.matchRemoteFunc(genericDataType, eventType);"),
+                "The post resource function's dispatch call must not use check - a handler error should "
+                        + "be caught and logged, not propagated and left unacknowledged");
+    }
+
+    @Test
     void testEmptyServiceTypesThrows() {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
         try {


### PR DESCRIPTION
## Purpose
While preparing to fully regenerate `module-ballerinax-github.trigger` from its spec (see `ballerina-platform/ballerina-library#8877`), checked whether the generator's HTTP webhook output actually reproduces behavior already fixed and tested in the shipped package. It does not - two\ real bugs in `asyncapi-generator`'s HTTP webhook path, one of which is severe enough to reject every real webhook delivery if left unfixed. Filing/fixing separately from the trigger regeneration because this generator is shared - any webhook trigger it produces is affected, not just GitHub's.

Resolves https://github.com/ballerina-platform/ballerina-library/issues/9004

## Goals
- Stop the generated dispatcher from silently swallowing acknowledgements when a user's handler errors, which currently causes the sender to see a failed delivery and retry.
- Make the generated dispatch tests build a correctly-prefixed signature (matching a spec's configured `headerFormat`) and assert the status code the dispatcher actually returns.

## Approach
`GeneratePostResourceFunctionNode.java`: moved the acknowledgement before the dispatch call, and changed the dispatch call to capture a handler error (`log:printError`) instead of propagating it via `check` - so a downstream handler failure can never block the response. Also fixed the acknowledgement itself: `caller->respond(http:STATUS_OK)` sends the status constant as the response *body* (an `anydata` payload), not as the status code - the framework was silently falling back to its per-method default (201 Created for POST) regardless. Now builds a real `http:Response` with `statusCode` set explicitly, matching the pattern already used for the 401 branch just above it.

`DispatchTestGenerator.java`: replaced the hardcoded bare-hex signature in generated tests with one built from the configured `headerFormat` (reusing `HeaderTemplateParser`, already shared with `GenerateVerifyWebhookSignatureFuncNode`), and fixed the generated assertion from `http:STATUS_CREATED` to `http:STATUS_OK`. Also added a `waitForDispatch` polling helper to
generated tests: since the ack is now sent before dispatch, the test client can receive its HTTP response before the server has finished running the matched handler on its own thread, so a single immediate check of the fired-flag map is no longer reliable.

## User stories
As a maintainer regenerating a webhook trigger from its spec, the generated code should already match previously-verified, hand-patched behavior - not require re-discovering and re-patching the same bugs every time.

## Release note
Fix: generated webhook dispatchers now acknowledge the delivery before invoking the matched handler (so handler errors don't cause delivery retries), and generated dispatch tests build a correctly-prefixed signature and assert the correct status code.

## Documentation
N/A 

## Automation tests
- Unit tests: added `DispatcherGeneratorTest.testAckSentBeforeDispatchAndDispatchErrorsAreNotPropagated`
  (asserts ack precedes dispatch, and the dispatch call doesn't use `check`) and `WebhookDSLVerificationTest.testGithubDispatchTestSignatureFormatAndStatusCode` (asserts the generated test's signature construction and status assertion). Full `asyncapi-generator` module: 334/334 passing.
- Integration tests: verified end to end by regenerating `module-ballerinax-github.trigger` with this branch and running its full test suite (265/265 passing) against real Octokit sample webhook payloads.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no (not run in this environment)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Test environment
Windows 11, OpenJDK 21 (Temurin), Ballerina Swan Lake 2201.13.x.
