### PR TITLE
Fix data_types.bal always importing ballerina/http even when unused

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
@@ -25,6 +25,7 @@ import io.ballerina.asyncapi.generator.http.node.GenerateListenerConfigNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateModuleMemberDeclarationNode;
 import io.ballerina.asyncapi.generator.http.node.GenerateUnionDescriptorNode;
 import io.ballerina.asyncapi.generator.http.node.Generator;
+import io.ballerina.asyncapi.generator.http.utils.CodegenUtils;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -96,13 +97,16 @@ public class DataTypesGenerator {
         Generator unionGen = new GenerateUnionDescriptorNode(typeDescriptors, GENERIC_DATA_TYPE);
         typeNodes.add(unionGen.generate());
 
-        ImportDeclarationNode importNode = GenerateHttpImportNode.generate();
+        List<ImportDeclarationNode> imports = new ArrayList<>();
+        if (needsHttpImport()) {
+            imports.add(GenerateHttpImportNode.generate());
+        }
 
         TextDocument textDocument = TextDocuments.from("");
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         ModulePartNode oldRoot = syntaxTree.rootNode();
         ModulePartNode newRoot = oldRoot.modify()
-                .withImports(createNodeList(importNode))
+                .withImports(createNodeList(imports))
                 .withMembers(oldRoot.members().addAll(typeNodes))
                 .apply();
         SyntaxTree modifiedTree = syntaxTree.replaceNode(oldRoot, newRoot);
@@ -112,5 +116,22 @@ public class DataTypesGenerator {
         } catch (FormatterException e) {
             throw new GeneratorException("Could not format the generated data_types.bal code", e);
         }
+    }
+
+    /**
+     * Determines whether {@code data_types.bal} needs {@code import ballerina/http;}. The only
+     * thing in this file that ever references {@code http:} is an {@code @http:Header {...}}
+     * annotation, generated for any schema property whose name requires one (see
+     * {@link CodegenUtils#requiresHeaderAnnotation}). Ballerina treats an unused import as a
+     * compile error, not a warning, so the import must only be added when at least one property
+     * actually needs that annotation.
+     *
+     * @return {@code true} if any schema field name requires an {@code @http:Header} annotation
+     */
+    private boolean needsHttpImport() {
+        return schemas.values().stream()
+                .filter(schema -> schema.properties() != null)
+                .flatMap(schema -> schema.properties().keySet().stream())
+                .anyMatch(CodegenUtils::requiresHeaderAnnotation);
     }
 }

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.asyncapi.generator.http.generator;
+
+import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
+import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link DataTypesGenerator}, specifically covering when {@code import
+ * ballerina/http;} should and should not be emitted. Ballerina rejects an unused import as a
+ * compile error, so the import must only be added when a schema field actually needs the
+ * {@code @http:Header} annotation it enables.
+ */
+public class DataTypesGeneratorTest {
+
+    @Test
+    void testGenerateWithNoHyphenatedFieldsOmitsHttpImport() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of(
+                        "eventId", AsyncApiSchema.builder().type("string").build(),
+                        "leadId", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        String result = new DataTypesGenerator(Map.of("LeadEvent", schema), Optional.empty()).generate();
+
+        Assert.assertFalse(result.contains("import ballerina/http;"),
+                "No field needs @http:Header, so the http import should not be generated: " + result);
+        Assert.assertFalse(result.contains("@http:Header"), "No field should get an @http:Header annotation");
+    }
+
+    @Test
+    void testGenerateWithHyphenatedFieldIncludesHttpImportAndHeaderAnnotation() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of(
+                        "X-Test-Header", AsyncApiSchema.builder().type("string").build(),
+                        "leadId", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        String result = new DataTypesGenerator(Map.of("LeadEvent", schema), Optional.empty()).generate();
+
+        Assert.assertTrue(result.contains("import ballerina/http;"),
+                "The 'X-Test-Header' field name requires @http:Header, so the http import "
+                        + "must be generated: " + result);
+        Assert.assertTrue(result.contains("@http:Header"), "The hyphenated field should get an @http:Header "
+                + "annotation: " + result);
+    }
+
+    @Test
+    void testGenerateWithNoPropertiesOmitsHttpImport() throws GeneratorException {
+        // A schema with no properties at all has nothing that could ever need @http:Header.
+        AsyncApiSchema schema = AsyncApiSchema.builder().type("object").build();
+        String result = new DataTypesGenerator(Map.of("EmptyEvent", schema), Optional.empty()).generate();
+
+        Assert.assertFalse(result.contains("import ballerina/http;"),
+                "A schema with no properties can't need @http:Header: " + result);
+    }
+}

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
@@ -19,7 +19,6 @@ package io.ballerina.asyncapi.generator.http.generator;
 
 import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
 import io.ballerina.asyncapi.generator.GeneratorException;
-import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/asyncapi-generator/src/test/resources/specs/github.json
+++ b/asyncapi-generator/src/test/resources/specs/github.json
@@ -85,34 +85,62 @@
       "PushEvent": {
         "type": "object",
         "properties": {
+          "event": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" }
+            },
+            "required": ["type"]
+          },
           "ref": { "type": "string" },
           "before": { "type": "string" },
           "after": { "type": "string" }
         },
-        "required": ["ref", "before", "after"]
+        "required": ["event", "ref", "before", "after"]
       },
       "GenericEvent": {
         "type": "object",
         "properties": {
+          "event": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" }
+            },
+            "required": ["type"]
+          },
           "action": { "type": "string" }
         },
-        "required": ["action"]
+        "required": ["event", "action"]
       },
       "IssueEvent": {
         "type": "object",
         "properties": {
+          "event": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" }
+            },
+            "required": ["type"]
+          },
           "action": { "type": "string" },
           "number": { "type": "integer" }
         },
-        "required": ["action", "number"]
+        "required": ["event", "action", "number"]
       },
       "DeploymentEvent": {
         "type": "object",
         "properties": {
+          "event": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" }
+            },
+            "required": ["type"]
+          },
           "action": { "type": "string" },
           "environment": { "type": "string" }
         },
-        "required": ["action"]
+        "required": ["event", "action"]
       }
     }
   }

--- a/asyncapi-generator/src/test/resources/testng.xml
+++ b/asyncapi-generator/src/test/resources/testng.xml
@@ -19,6 +19,7 @@
             <class name="io.ballerina.asyncapi.generator.http.extractor.ServiceTypeExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.SchemaExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ListenerGeneratorTest"/>
+            <class name="io.ballerina.asyncapi.generator.http.generator.DataTypesGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.DispatcherGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ServiceTypesGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.utils.CodegenUtilsTest"/>


### PR DESCRIPTION
## Purpose

`data_types.bal` always added `import ballerina/http;` regardless of whether anything in the generated file actually referenced `http:`. Ballerina treats an unused import as a compile error, not a warning, so nearly every generated trigger failed `bal build` immediately - only specs where a field name happened to need an `@http:Header` annotation (or the connection-auth scheme is `X509`, on a separate in-progress branch) ever avoided it by chance.

Resolves https://github.com/ballerina-platform/ballerina-library/issues/9030

## Goals

- Only emit `import ballerina/http;` in `data_types.bal` when something in the file genuinely needs it.
- Fix a second, unrelated bug this uncovered: the `github.json` test fixture's event identifier path didn't match its own schemas, so it kept failing even after the import fix, on a completely different error.

## Approach

`DataTypesGenerator.generate()` now checks, before building the import list, whether any schema field name requires an `@http:Header` annotation - reusing `CodegenUtils.requiresHeaderAnnotation()`, which is already the single source of truth for that same decision elsewhere in the generator (it's what decides whether a field gets the annotation in the first place). The `http` import is only added when that check is true.

While re-verifying the fix against every fixture already in the test suite, `github.json` still failed `bal build`, but for a different, unrelated reason: its `x-ballerina-event-identifier` declares `path: "event.type"`, but none of its four schemas (`PushEvent`, `GenericEvent`, `IssueEvent`, `DeploymentEvent`) had an `event` field. The generated dispatcher statically requires every member of that payload union to declare the field, so it failed to compile. Confirmed this was a fixture bug, not a generator bug, by comparing against `slack_verification.yaml`, which uses the identical `path: "event.type"` and compiles correctly, because its schema genuinely has a nested `event: {type: object, properties: {type: string}}`. Fixed `github.json` by adding that same shape (as a required field) to all four of its schemas, matching what its own identifier path already declared.

Both fixes were verified against real generated output, not just generated text: ran the actual Ballerina compiler (`bal build`) on output generated from `sendgrid_minimal.json` and the corrected `github.json`, and both now produce real executable jars.

## Release note

Fixed a code generation bug where `data_types.bal` could fail to compile with an "unused module prefix 'http'" error for specs that don't require an `@http:Header` annotation on any field.

## Documentation

N/A 

## Training

N/A 

## Certification

N/A 

## Marketing

N/A 

## Automation tests

- Unit tests
  > Added `DataTypesGeneratorTest` (3 new cases): a schema with no hyphenated field names omits
  > the import; a schema with a hyphenated field name includes both the import and the
  > `@http:Header` annotation; a schema with no properties at all omits the import. Full
  > `asyncapi-generator` module suite: 335/335 passing, no regressions.
- Integration tests
  > No new integration test class added; verified instead via direct `bal build` against real
  > generated output for `sendgrid_minimal.json` (previously failed on the unused import, now
  > compiles to a jar) and the corrected `github.json` (previously failed first on the unused
  > import, then on the fixture mismatch once that was fixed; now compiles to a jar).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A 

## Migrations (if applicable)

N/A

## Test environment

- Ballerina 2201.13.4 (Swan Lake Update 13), Language specification 2024R1
- JDK: Temurin-21.0.2+13 (OpenJDK 21.0.2 LTS)
- OS: Windows 11 Pro
- Build tool: Gradle (via this repo's existing wrapper)

