### PR TITLE
Add generator doc comments, always-hoist inline objects, and 4 permanent regen fixes

### DIFF
--- a/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/Constants.java
+++ b/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/Constants.java
@@ -63,6 +63,7 @@ public final class Constants {
     public static final String SCHEMA_UNIQUE_ITEMS = "uniqueItems";
     public static final String SCHEMA_MAX_PROPERTIES = "maxProperties";
     public static final String SCHEMA_MIN_PROPERTIES = "minProperties";
+    public static final String SCHEMA_NULLABLE = "nullable";
     public static final String SCHEMA_READ_ONLY = "readOnly";
     public static final String SCHEMA_WRITE_ONLY = "writeOnly";
     public static final String SCHEMA_DEPRECATED = "deprecated";

--- a/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/implementation/common/SchemaMapper.java
+++ b/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/implementation/common/SchemaMapper.java
@@ -132,6 +132,7 @@ public final class SchemaMapper {
                 .externalDocs(ExternalDocMapperV2.map(externalDocs))
                 .deprecated(schema.isDeprecated())
                 .extensions(extensions)
+                .nullable(mapNullable(schema))
                 .build();
     }
 
@@ -198,9 +199,14 @@ public final class SchemaMapper {
                 String refName = ref.substring(ref.lastIndexOf('/') + 1);
                 io.ballerina.asyncapi.core.model.component.AsyncApiSchema stub =
                         io.ballerina.asyncapi.core.model.component.AsyncApiSchema.refStub(refName);
-                if (entry.getValue() instanceof AsyncApiSchema typedSchema
-                        && typedSchema.getDescription() != null) {
-                    stub = stub.withDescription(typedSchema.getDescription());
+                if (entry.getValue() instanceof AsyncApiSchema typedSchema) {
+                    if (typedSchema.getDescription() != null) {
+                        stub = stub.withDescription(typedSchema.getDescription());
+                    }
+                    Boolean siblingNullable = mapNullable(typedSchema);
+                    if (siblingNullable != null) {
+                        stub = stub.withNullable(siblingNullable);
+                    }
                 }
                 properties.put(entry.getKey(), stub);
             } else if (entry.getValue() instanceof AsyncApiSchema typedSchema) {
@@ -225,6 +231,26 @@ public final class SchemaMapper {
             return extensible.getExtensions();
         }
         return null;
+    }
+
+    /**
+     * Extracts the standard {@code nullable} keyword from a schema.
+     *
+     * <p>Apicurio's AsyncAPI 3.0 schema model doesn't define {@code nullable} as a typed field
+     * (that dialect's JSON Schema subset has no such keyword - a nullable value is properly
+     * expressed as a {@code type} union with {@code "null"} instead), so a real-world spec that
+     * still uses the OpenAPI-style {@code nullable: true} convention has it captured only in the
+     * node's generic extra-properties bucket. It's also not picked up by {@link #mapExtensions},
+     * since that only surfaces {@code x-}-prefixed vendor extensions, not arbitrary unrecognized
+     * keywords - so it has to be read via {@link Schema#getExtraProperty(String)} directly.
+     *
+     * @param schema the Apicurio schema object
+     * @return {@code true}/{@code false} if the schema declares {@code nullable} explicitly,
+     *         {@code null} if it's absent
+     */
+    private static Boolean mapNullable(AsyncApiSchema schema) {
+        JsonNode nullableNode = schema.getExtraProperty(Constants.SCHEMA_NULLABLE);
+        return nullableNode != null && nullableNode.isBoolean() ? nullableNode.booleanValue() : null;
     }
 
     /**
@@ -354,6 +380,10 @@ public final class SchemaMapper {
                         if (siblingDescription != null) {
                             stub = stub.withDescription(siblingDescription);
                         }
+                    }
+                    JsonNode nullableNode = propNode.get(Constants.SCHEMA_NULLABLE);
+                    if (nullableNode != null && nullableNode.isBoolean()) {
+                        stub = stub.withNullable(nullableNode.booleanValue());
                     }
                     propsRef.put(entry.getKey(), stub);
                 } else {

--- a/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/model/component/AsyncApiSchema.java
+++ b/asyncapi-core/src/main/java/io/ballerina/asyncapi/core/model/component/AsyncApiSchema.java
@@ -80,6 +80,11 @@ import java.util.Map;
  *                             {@code #/components/schemas}. Not part of JSON Schema; stamped by
  *                             the mapper when a {@code $ref} payload is resolved so that code
  *                             generators can use the component name as the Ballerina type name.
+ * @param nullable             The standard AsyncAPI/OpenAPI {@code nullable} keyword - {@code true}
+ *                             if the value may be {@code null} in addition to matching {@code type}.
+ *                             Not a recognized field in apicurio's AsyncAPI 3.0 schema model (that
+ *                             dialect has no {@code nullable} keyword), so it's read from the
+ *                             schema's generic extra-properties bucket rather than a typed accessor.
  */
 public record AsyncApiSchema(
         String title,
@@ -124,7 +129,8 @@ public record AsyncApiSchema(
         AsyncApiExternalDocs externalDocs,
         Boolean deprecated,
         Map<String, JsonNode> extensions,
-        String name
+        String name,
+        Boolean nullable
 ) {
 
     /**
@@ -164,7 +170,7 @@ public record AsyncApiSchema(
                 writeOnly(), properties(), patternProperties(), additionalProperties(),
                 additionalItems(), items(), propertyNames(), contains(), allOf(),
                 oneOf(), anyOf(), not(), description(), format(), defaultValue(),
-                discriminator(), externalDocs(), deprecated(), extensions(), name()
+                discriminator(), externalDocs(), deprecated(), extensions(), name(), nullable()
         );
     }
 
@@ -185,7 +191,30 @@ public record AsyncApiSchema(
                 writeOnly(), properties(), patternProperties(), additionalProperties(),
                 additionalItems(), items(), propertyNames(), contains(), allOf(),
                 oneOf(), anyOf(), not(), newDescription, format(), defaultValue(),
-                discriminator(), externalDocs(), deprecated(), extensions(), name()
+                discriminator(), externalDocs(), deprecated(), extensions(), name(), nullable()
+        );
+    }
+
+    /**
+     * Returns a copy of this schema with the given {@code nullable}, preserving all other fields.
+     * Used to attach a sibling {@code nullable} from a {@code $ref} property node onto the
+     * resolved stub schema - {@code $ref} plus a sibling {@code nullable: true} is exactly how a
+     * spec marks a referenced type as nullable (e.g. {@code assignee: {$ref: '#/.../User',
+     * nullable: true}}), and the stub otherwise carries nothing but {@code name}.
+     *
+     * @param newNullable the nullable flag to set
+     * @return a new {@link AsyncApiSchema} with the given nullable flag
+     */
+    public AsyncApiSchema withNullable(Boolean newNullable) {
+        return new AsyncApiSchema(
+                title(), type(), required(), multipleOf(), maximum(), exclusiveMaximum(),
+                minimum(), exclusiveMinimum(), maxLength(), minLength(), pattern(),
+                maxItems(), minItems(), uniqueItems(), maxProperties(), minProperties(),
+                enumValue(), constValue(), examples(), ifBranch(), then(), elseBranch(), readOnly(),
+                writeOnly(), properties(), patternProperties(), additionalProperties(),
+                additionalItems(), items(), propertyNames(), contains(), allOf(),
+                oneOf(), anyOf(), not(), description(), format(), defaultValue(),
+                discriminator(), externalDocs(), deprecated(), extensions(), name(), newNullable
         );
     }
 
@@ -206,7 +235,7 @@ public record AsyncApiSchema(
                 writeOnly(), properties(), patternProperties(), additionalProperties(),
                 additionalItems(), items(), propertyNames(), contains(), allOf(),
                 oneOf(), anyOf(), not(), description(), format(), defaultValue(),
-                discriminator(), externalDocs(), deprecated(), extensions(), newName
+                discriminator(), externalDocs(), deprecated(), extensions(), newName, nullable()
         );
     }
 
@@ -269,6 +298,7 @@ public record AsyncApiSchema(
         Boolean deprecated;
         Map<String, JsonNode> extensions;
         String name;
+        Boolean nullable;
 
         private Builder() {
         }
@@ -488,6 +518,11 @@ public record AsyncApiSchema(
             return this;
         }
 
+        public Builder nullable(Boolean nullable) {
+            this.nullable = nullable;
+            return this;
+        }
+
         /**
          * Constructs the {@link AsyncApiSchema} from the values set on this builder.
          *
@@ -505,7 +540,7 @@ public record AsyncApiSchema(
                     additionalItems, items, propertyNames, contains,
                     allOf, oneOf, anyOf, not,
                     description, format, defaultValue, discriminator, externalDocs,
-                    deprecated, extensions, name
+                    deprecated, extensions, name, nullable
             );
         }
     }

--- a/asyncapi-core/src/test/java/io/ballerina/asyncapi/core/AsyncApiParserIntegrationTest.java
+++ b/asyncapi-core/src/test/java/io/ballerina/asyncapi/core/AsyncApiParserIntegrationTest.java
@@ -495,6 +495,49 @@ public class AsyncApiParserIntegrationTest {
     }
 
     @Test
+    void v300_standardNullableKeyword_isCapturedOnSchema() throws AsyncApiParserException {
+        // AsyncAPI 3.0's JSON Schema dialect has no typed 'nullable' keyword (Apicurio's schema
+        // model doesn't expose one), so a real-world spec still using the OpenAPI-style
+        // 'nullable: true' convention must be read from the schema's generic extra-properties
+        // bucket rather than a typed accessor or the x-prefixed extensions map - see
+        // SchemaMapper#mapNullable.
+        String json = "{\"asyncapi\":\"3.0.0\",\"info\":{\"title\":\"T\",\"version\":\"1\"},\"channels\":{},"
+                + "\"components\":{\"schemas\":{\"Foo\":{\"type\":\"object\",\"properties\":{"
+                + "\"bar\":{\"type\":\"string\",\"nullable\":true},"
+                + "\"baz\":{\"type\":\"string\"}}}}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        AsyncApiComponent components = spec.getAsyncApiComponents().orElseThrow();
+        AsyncApiSchema foo = components.schemas().get("Foo");
+        Assert.assertEquals(foo.properties().get("bar").nullable(), Boolean.TRUE,
+                "A field marked 'nullable: true' should have nullable() == true");
+        Assert.assertNull(foo.properties().get("baz").nullable(),
+                "A field with no 'nullable' keyword should have nullable() == null, not false");
+    }
+
+    @Test
+    void v300_refWithSiblingNullable_isCapturedOnStub() throws AsyncApiParserException {
+        // A field that's a $ref PLUS a sibling 'nullable: true' - real-world shape, e.g. GitHub's
+        // spec: assignee: {$ref: '#/components/schemas/User', nullable: true}. The property maps
+        // to a minimal ref stub (only 'name' set) rather than going through the normal schema
+        // mapping path, so the sibling 'nullable' has to be attached onto that stub explicitly,
+        // mirroring how a sibling 'description' is already attached (see SchemaMapper#mapProperties).
+        String json = "{\"asyncapi\":\"3.0.0\",\"info\":{\"title\":\"T\",\"version\":\"1\"},\"channels\":{},"
+                + "\"components\":{\"schemas\":{"
+                + "\"User\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"}}},"
+                + "\"PullRequestPayload\":{\"type\":\"object\",\"required\":[\"assignee\"],"
+                + "\"properties\":{\"assignee\":{\"$ref\":\"#/components/schemas/User\",\"nullable\":true}}}"
+                + "}}}";
+        AsyncApiSpec spec = AsyncApiParser.parseFromJsonString(json);
+        AsyncApiComponent components = spec.getAsyncApiComponents().orElseThrow();
+        AsyncApiSchema payload = components.schemas().get("PullRequestPayload");
+        AsyncApiSchema assignee = payload.properties().get("assignee");
+        Assert.assertEquals(assignee.name(), "User",
+                "The $ref stub should still resolve to the referenced schema's name");
+        Assert.assertEquals(assignee.nullable(), Boolean.TRUE,
+                "The sibling 'nullable: true' next to the $ref must be attached onto the stub");
+    }
+
+    @Test
     void nullInput_throwsAsyncApiParserException() {
         Assert.assertThrows(AsyncApiParserException.class, () -> AsyncApiParser.parseFromJsonString(null));
     }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
@@ -108,7 +108,8 @@ public class HttpCodeGenerator {
         // Generate Ballerina source content
         String dataTypesContent = new DataTypesGenerator(schemas, webhookAuthConfig).generate();
         String serviceTypesContent = new ServiceTypesGenerator(serviceTypes).generate();
-        String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig).generate();
+        String displayLabel = asyncApiSpec.getAsyncApiInfo().title();
+        String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig, displayLabel).generate();
         String dispatcherContent =
                 new DispatcherGenerator(serviceTypes, identifierConfig, webhookAuthConfig)
                 .generate();

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/HttpCodeGenerator.java
@@ -109,9 +109,8 @@ public class HttpCodeGenerator {
         String dataTypesContent = new DataTypesGenerator(schemas, webhookAuthConfig).generate();
         String serviceTypesContent = new ServiceTypesGenerator(serviceTypes).generate();
         String listenerContent = new ListenerGenerator(serviceTypes, webhookAuthConfig).generate();
-        String serviceName = deriveServiceName(outputPath);
         String dispatcherContent =
-                new DispatcherGenerator(serviceTypes, identifierConfig, webhookAuthConfig, serviceName)
+                new DispatcherGenerator(serviceTypes, identifierConfig, webhookAuthConfig)
                 .generate();
 
         // Write generated files to the output directory
@@ -148,23 +147,6 @@ public class HttpCodeGenerator {
         if (webhookAuthConfig.isPresent()) {
             WebhookDslValidator.validate(webhookAuthConfig.get());
         }
-    }
-
-    /**
-     * Derives a diagnostic-log label for the package being generated from the output directory name.
-     *
-     * <p>Embedded into the {@code MATCH_LEVEL_1_*}, {@code MATCH_LEVEL_2_*}, and
-     * {@code HANDLER_EXECUTED_*} trace logs in {@code dispatcher_service.bal} so that logs from
-     * multiple generated packages running side by side can be told apart.
-     *
-     * @param outputPath the directory the generated files are being written to
-     * @return a sanitized, non-empty label safe to splice into a Ballerina string literal
-     */
-    private static String deriveServiceName(Path outputPath) {
-        Path fileName = outputPath.toAbsolutePath().normalize().getFileName();
-        String raw = fileName == null ? "service" : fileName.toString();
-        String sanitized = raw.replaceAll("[^A-Za-z0-9_]", "_");
-        return sanitized.isBlank() ? "service" : sanitized;
     }
 
     /**

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
@@ -85,19 +85,11 @@ public class DataTypesGenerator {
         typeNodes.add(GenerateListenerConfigNode.generateDefaultSecretConst());
         typeNodes.add(GenerateListenerConfigNode.generate(extraConfigFields));
 
-        // Split into two groups instead of one list, so "loose" schemas (every property optional -
-        // the shape cloneWithType's first-match union resolution can most easily mismatch, since an
-        // unrelated payload can satisfy an all-optional record structurally) are ordered after every
-        // concrete schema in the union, regardless of the order schemas.entrySet() happens to iterate
-        // in. See isLooseObjectSchema's javadoc.
+        // Loose schemas (see isLooseObjectSchema) are ordered last in the union.
         List<TypeDescriptorNode> strictTypeDescriptors = new ArrayList<>();
         List<TypeDescriptorNode> looseTypeDescriptors = new ArrayList<>();
 
-        // Shared across every entry's generator so two different schemas hoisting an inline object
-        // with the same field name (e.g. two payloads each with an inline "workflow" object) can
-        // never produce two colliding type definitions - see GenerateModuleMemberDeclarationNode's
-        // constructor javadoc. Seeded with every top-level schema's own (post-sanitization) name,
-        // since a hoisted type must not collide with those either.
+        // Shared across entries so hoisted inline types can't collide on name.
         Set<String> claimedTypeNames = new HashSet<>();
         for (String schemaName : schemas.keySet()) {
             claimedTypeNames.add(CodegenUtils.getValidName(CodegenUtils.escapeIdentifier(schemaName.trim()), true));

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGenerator.java
@@ -38,9 +38,11 @@ import org.ballerinalang.formatter.core.Formatter;
 import org.ballerinalang.formatter.core.FormatterException;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createNodeList;
@@ -82,17 +84,44 @@ public class DataTypesGenerator {
         List<ModuleMemberDeclarationNode> typeNodes = new ArrayList<>();
         typeNodes.add(GenerateListenerConfigNode.generateDefaultSecretConst());
         typeNodes.add(GenerateListenerConfigNode.generate(extraConfigFields));
-        List<TypeDescriptorNode> typeDescriptors = new ArrayList<>();
+
+        // Split into two groups instead of one list, so "loose" schemas (every property optional -
+        // the shape cloneWithType's first-match union resolution can most easily mismatch, since an
+        // unrelated payload can satisfy an all-optional record structurally) are ordered after every
+        // concrete schema in the union, regardless of the order schemas.entrySet() happens to iterate
+        // in. See isLooseObjectSchema's javadoc.
+        List<TypeDescriptorNode> strictTypeDescriptors = new ArrayList<>();
+        List<TypeDescriptorNode> looseTypeDescriptors = new ArrayList<>();
+
+        // Shared across every entry's generator so two different schemas hoisting an inline object
+        // with the same field name (e.g. two payloads each with an inline "workflow" object) can
+        // never produce two colliding type definitions - see GenerateModuleMemberDeclarationNode's
+        // constructor javadoc. Seeded with every top-level schema's own (post-sanitization) name,
+        // since a hoisted type must not collide with those either.
+        Set<String> claimedTypeNames = new HashSet<>();
+        for (String schemaName : schemas.keySet()) {
+            claimedTypeNames.add(CodegenUtils.getValidName(CodegenUtils.escapeIdentifier(schemaName.trim()), true));
+        }
 
         for (Map.Entry<String, AsyncApiSchema> entry : schemas.entrySet()) {
-            Generator gen = new GenerateModuleMemberDeclarationNode(entry, schemas);
+            GenerateModuleMemberDeclarationNode gen =
+                    new GenerateModuleMemberDeclarationNode(entry, schemas, claimedTypeNames);
             ModuleMemberDeclarationNode node = gen.generate();
             if (node instanceof TypeDefinitionNode typeDefNode) {
-                typeDescriptors.add(createSimpleNameReferenceNode(
-                        createIdentifierToken(typeDefNode.typeName().text())));
+                TypeDescriptorNode reference = createSimpleNameReferenceNode(
+                        createIdentifierToken(typeDefNode.typeName().text()));
+                if (isLooseObjectSchema(entry.getValue())) {
+                    looseTypeDescriptors.add(reference);
+                } else {
+                    strictTypeDescriptors.add(reference);
+                }
             }
             typeNodes.add(node);
+            typeNodes.addAll(gen.getHoistedTypes());
         }
+
+        List<TypeDescriptorNode> typeDescriptors = new ArrayList<>(strictTypeDescriptors);
+        typeDescriptors.addAll(looseTypeDescriptors);
 
         Generator unionGen = new GenerateUnionDescriptorNode(typeDescriptors, GENERIC_DATA_TYPE);
         typeNodes.add(unionGen.generate());
@@ -133,5 +162,29 @@ public class DataTypesGenerator {
                 .filter(schema -> schema.properties() != null)
                 .flatMap(schema -> schema.properties().keySet().stream())
                 .anyMatch(CodegenUtils::requiresHeaderAnnotation);
+    }
+
+    /**
+     * A top-level object schema is "loose" if it declares properties but requires none of them
+     * (e.g. {@code Installation}: {@code record { int id?; string node_id?; }}). Ballerina's
+     * {@code cloneWithType} resolves a union target by a first-match policy - if a member's shape
+     * is permissive enough to structurally accept almost any object, it can capture a payload that
+     * was really meant for a more specific, concrete member listed later in the union. Ordering
+     * loose members last in {@code GenericDataType} avoids that, without needing to guess at
+     * exactly which other payload a given loose schema might collide with.
+     *
+     * <p>Only applies to schemas that generate as a plain record (mirrors the
+     * {@code generateRecord} branch in {@link GenerateModuleMemberDeclarationNode#generate()}) -
+     * enums, type aliases, and {@code allOf}-merged records have different {@code cloneWithType}
+     * matching semantics and aren't reordered by this rule.
+     *
+     * @param schema the top-level schema to classify
+     * @return {@code true} if the schema has properties but none are required
+     */
+    private boolean isLooseObjectSchema(AsyncApiSchema schema) {
+        if (schema.properties() == null || schema.properties().isEmpty()) {
+            return false;
+        }
+        return schema.required() == null || schema.required().isEmpty();
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGenerator.java
@@ -56,7 +56,6 @@ public class DispatcherGenerator {
     private final List<HttpServiceType> serviceTypes;
     private final EventIdentifierConfig identifierConfig;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
-    private final String serviceName;
 
     /**
      * Creates a generator for the given service types, event identifier configuration, and optional
@@ -65,16 +64,12 @@ public class DispatcherGenerator {
      * @param serviceTypes      the list of HTTP service type definitions
      * @param identifierConfig  the resolved event identifier type and path
      * @param webhookAuthConfig the optional webhook authentication configuration
-     * @param serviceName       a label identifying the generated package, embedded into the
-     *                          {@code MATCH_LEVEL_1_*}, {@code MATCH_LEVEL_2_*}, and
-     *                          {@code HANDLER_EXECUTED_*} diagnostic trace log messages
      */
     public DispatcherGenerator(List<HttpServiceType> serviceTypes, EventIdentifierConfig identifierConfig,
-            Optional<WebhookAuthConfig> webhookAuthConfig, String serviceName) {
+            Optional<WebhookAuthConfig> webhookAuthConfig) {
         this.serviceTypes = serviceTypes;
         this.identifierConfig = identifierConfig;
         this.webhookAuthConfig = webhookAuthConfig;
-        this.serviceName = serviceName;
     }
 
     /**
@@ -98,7 +93,7 @@ public class DispatcherGenerator {
         }
 
         ClassDefinitionNode classNode =
-                new GenerateDispatcherServiceNode(serviceTypes, identifierConfig, webhookAuthConfig, serviceName)
+                new GenerateDispatcherServiceNode(serviceTypes, identifierConfig, webhookAuthConfig)
                         .generate();
 
         List<ImportDeclarationNode> imports = new ArrayList<>();

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ListenerGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ListenerGenerator.java
@@ -48,17 +48,20 @@ public class ListenerGenerator {
 
     private final List<HttpServiceType> serviceTypes;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
+    private final String displayLabel;
 
     /**
      * Creates a generator for the given list of service types and optional webhook auth configuration.
      *
      * @param serviceTypes      the list of HTTP service type definitions to generate
      * @param webhookAuthConfig the optional webhook authentication configuration
+     * @param displayLabel      the connector's display name, from the spec's {@code info.title}
      */
     public ListenerGenerator(List<HttpServiceType> serviceTypes,
-            Optional<WebhookAuthConfig> webhookAuthConfig) {
+            Optional<WebhookAuthConfig> webhookAuthConfig, String displayLabel) {
         this.serviceTypes = serviceTypes;
         this.webhookAuthConfig = webhookAuthConfig;
+        this.displayLabel = displayLabel;
     }
 
     /**
@@ -72,7 +75,8 @@ public class ListenerGenerator {
             throw new GeneratorException("No service types defined; cannot generate listener.bal");
         }
 
-        ClassDefinitionNode classNode = new GenerateListenerClassNode(serviceTypes, webhookAuthConfig).generate();
+        ClassDefinitionNode classNode =
+                new GenerateListenerClassNode(serviceTypes, webhookAuthConfig, displayLabel).generate();
         ImportDeclarationNode httpImport = GenerateHttpImportNode.generate();
         ImportDeclarationNode cloudImport = GenerateCloudImportNode.generate();
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateDispatcherServiceNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateDispatcherServiceNode.java
@@ -94,7 +94,6 @@ public class GenerateDispatcherServiceNode implements Generator {
     private final List<HttpServiceType> serviceTypes;
     private final EventIdentifierConfig identifierConfig;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
-    private final String serviceName;
 
     /**
      * Creates a generator for the {@code DispatcherService} class.
@@ -102,16 +101,12 @@ public class GenerateDispatcherServiceNode implements Generator {
      * @param serviceTypes      the list of HTTP service type definitions
      * @param identifierConfig  the resolved event identifier type and path
      * @param webhookAuthConfig the optional webhook authentication configuration
-     * @param serviceName       a label identifying the generated package, embedded into the
-     *                          {@code MATCH_LEVEL_1_*}, {@code MATCH_LEVEL_2_*}, and
-     *                          {@code HANDLER_EXECUTED_*} diagnostic trace log messages
      */
     public GenerateDispatcherServiceNode(List<HttpServiceType> serviceTypes, EventIdentifierConfig identifierConfig,
-                                         Optional<WebhookAuthConfig> webhookAuthConfig, String serviceName) {
+                                         Optional<WebhookAuthConfig> webhookAuthConfig) {
         this.serviceTypes = serviceTypes;
         this.identifierConfig = identifierConfig;
         this.webhookAuthConfig = webhookAuthConfig;
-        this.serviceName = serviceName;
     }
 
     @Override
@@ -143,7 +138,7 @@ public class GenerateDispatcherServiceNode implements Generator {
         }
         
         GenerateMatchRemoteFuncNode matchRemoteFuncGen =
-                new GenerateMatchRemoteFuncNode(serviceTypes, identifierConfig, eventIdentifierPath, serviceName);
+                new GenerateMatchRemoteFuncNode(serviceTypes, identifierConfig, eventIdentifierPath);
         members.add(buildFunc(matchRemoteFuncGen));
 
         // Add one chunk function per channel group if chunking was triggered
@@ -151,7 +146,7 @@ public class GenerateDispatcherServiceNode implements Generator {
             members.add(buildFunc(chunkGen));
         }
 
-        members.add(buildFunc(new GenerateExecuteRemoteFuncNode(serviceName)));
+        members.add(buildFunc(new GenerateExecuteRemoteFuncNode()));
 
         return createClassDefinitionNode(
                 null,

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateExecuteRemoteFuncNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateExecuteRemoteFuncNode.java
@@ -63,16 +63,10 @@ public class GenerateExecuteRemoteFuncNode implements Generator {
     private static final String EXECUTE_REMOTE_FUNC_PARAM_EVENT_FUNC = "eventFunction";
     private static final String EXECUTE_REMOTE_FUNC_LOCAL_SERVICE = "genericService";
 
-    private final String serviceName;
-
     /**
      * Creates a generator for the {@code executeRemoteFunc} method.
-     *
-     * @param serviceName a label identifying the generated package, embedded into the
-     *                    {@code HANDLER_EXECUTED_*} diagnostic trace log message
      */
-    public GenerateExecuteRemoteFuncNode(String serviceName) {
-        this.serviceName = serviceName;
+    public GenerateExecuteRemoteFuncNode() {
     }
 
     @Override
@@ -111,12 +105,9 @@ public class GenerateExecuteRemoteFuncNode implements Generator {
                 GenerateDispatcherServiceNode.DISPATCHER_SERVICES_FIELD,
                 EXECUTE_REMOTE_FUNC_PARAM_SERVICE_TYPE)));
         statements.add(NodeParser.parseStatement(String.format(
-                "if %s is %s { log:printInfo(\"HANDLER_EXECUTED_%s\", eventName = %s); "
-                        + "check self.%s.invokeRemoteFunction(%s, %s, %s, %s); }",
+                "if %s is %s { check self.%s.invokeRemoteFunction(%s, %s, %s, %s); }",
                 EXECUTE_REMOTE_FUNC_LOCAL_SERVICE,
                 ServiceTypesGenerator.GENERIC_SERVICE_TYPE,
-                serviceName,
-                EXECUTE_REMOTE_FUNC_PARAM_EVENT_NAME,
                 GenerateDispatcherServiceNode.DISPATCHER_NATIVE_HANDLER_FIELD,
                 EXECUTE_REMOTE_FUNC_PARAM_EVENT,
                 EXECUTE_REMOTE_FUNC_PARAM_EVENT_NAME,

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
@@ -22,6 +22,7 @@ import io.ballerina.asyncapi.generator.http.generator.ServiceTypesGenerator;
 import io.ballerina.asyncapi.generator.http.model.HttpServiceType;
 import io.ballerina.asyncapi.generator.http.model.WebhookAuthConfig;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
@@ -100,17 +101,20 @@ public class GenerateListenerClassNode implements Generator {
 
     private final List<HttpServiceType> serviceTypes;
     private final Optional<WebhookAuthConfig> webhookAuthConfig;
+    private final String displayLabel;
 
     /**
      * Creates a generator for the {@code Listener} class.
      *
      * @param serviceTypes      the list of HTTP service type definitions
      * @param webhookAuthConfig the optional webhook authentication configuration
+     * @param displayLabel      the connector's display name, from the spec's {@code info.title}
      */
     public GenerateListenerClassNode(List<HttpServiceType> serviceTypes,
-            Optional<WebhookAuthConfig> webhookAuthConfig) {
+            Optional<WebhookAuthConfig> webhookAuthConfig, String displayLabel) {
         this.serviceTypes = serviceTypes;
         this.webhookAuthConfig = webhookAuthConfig;
+        this.displayLabel = displayLabel;
     }
 
     @Override
@@ -149,11 +153,22 @@ public class GenerateListenerClassNode implements Generator {
                                         null,
                                         createIdentifierToken("label"),
                                         createToken(COLON_TOKEN),
-                                        createBasicLiteralNode(STRING_LITERAL,
-                                                createLiteralValueToken(STRING_LITERAL_TOKEN, "\"\"",
-                                                        createEmptyMinutiaeList(), createEmptyMinutiaeList())))),
+                                        createStringLiteralField(displayLabel)),
+                                createToken(COMMA_TOKEN),
+                                createSpecificFieldNode(
+                                        null,
+                                        createIdentifierToken("iconPath"),
+                                        createToken(COLON_TOKEN),
+                                        createStringLiteralField("icon.png"))),
                         createToken(CLOSE_BRACE_TOKEN)));
         return createMetadataNode(null, createNodeList(annotation));
+    }
+
+    private BasicLiteralNode createStringLiteralField(String value) {
+        String escaped = value.replace("\\", "\\\\").replace("\"", "\\\"");
+        return createBasicLiteralNode(STRING_LITERAL,
+                createLiteralValueToken(STRING_LITERAL_TOKEN, "\"" + escaped + "\"",
+                        createEmptyMinutiaeList(), createEmptyMinutiaeList()));
     }
 
     private ObjectFieldNode buildHttpListenerField() {

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerClassNode.java
@@ -280,7 +280,7 @@ public class GenerateListenerClassNode implements Generator {
 
         List<StatementNode> statements = new ArrayList<>();
         statements.add(NodeParser.parseStatement(String.format(
-                "string serviceTypeStr = self.%s(serviceRef);",
+                "string serviceTypeStr = check self.%s(serviceRef);",
                 LISTENER_GET_SERVICE_TYPE_FUNC)));
         statements.add(NodeParser.parseStatement(String.format(
                 "check self.%s.%s(serviceTypeStr, serviceRef);",
@@ -311,7 +311,7 @@ public class GenerateListenerClassNode implements Generator {
 
         List<StatementNode> statements = new ArrayList<>();
         statements.add(NodeParser.parseStatement(String.format(
-                "string serviceTypeStr = self.%s(serviceRef);",
+                "string serviceTypeStr = check self.%s(serviceRef);",
                 LISTENER_GET_SERVICE_TYPE_FUNC)));
         statements.add(NodeParser.parseStatement(String.format(
                 "check self.%s.%s(serviceTypeStr);",
@@ -398,7 +398,11 @@ public class GenerateListenerClassNode implements Generator {
     }
 
     private FunctionDefinitionNode buildGetServiceTypeStrFunc() throws GeneratorException {
-        // private isolated function getServiceTypeStr(GenericServiceType serviceRef) returns string
+        // private isolated function getServiceTypeStr(GenericServiceType serviceRef) returns string|error
+        // - string|error (not plain string) because an unrecognized serviceRef returns an error
+        // (see GenerateListenerStatementNode) rather than panicking, so a caller attaching a
+        // service type this listener doesn't understand gets a normal error instead of crashing
+        // the whole runtime process.
         FunctionSignatureNode signature = createFunctionSignatureNode(
                 createToken(OPEN_PAREN_TOKEN),
                 createSeparatedNodeList(
@@ -411,7 +415,10 @@ public class GenerateListenerClassNode implements Generator {
                 createReturnTypeDescriptorNode(
                         createToken(RETURNS_KEYWORD),
                         createEmptyNodeList(),
-                        createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string"))));
+                        createUnionTypeDescriptorNode(
+                                createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("string")),
+                                createToken(PIPE_TOKEN),
+                                createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("error")))));
 
         List<String> typeNames = serviceTypes.stream()
                 .map(HttpServiceType::serviceTypeName)

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerStatementNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateListenerStatementNode.java
@@ -94,8 +94,13 @@ public class GenerateListenerStatementNode implements Generator {
     /**
      * Builds the {@code else} branch: either a nested {@code if is <NextType>} check for the
      * remaining candidates, or -- once every known type has been explicitly tested and none
-     * matched -- a {@code panic}, so an unrecognized {@code serviceRef} fails loudly instead of
+     * matched -- a {@code return error(...)}, so an unrecognized {@code serviceRef} fails loudly
+     * (the caller, {@code attach}/{@code detach}, propagates it via {@code check}) instead of
      * being silently mislabeled as whichever type happened to be last in the list.
+     *
+     * <p>Returns an {@code error}, not a {@code panic}: a {@code panic} would crash the entire
+     * running listener process over one bad {@code attach} call, whereas returning an error lets
+     * the caller handle it as an ordinary failed operation.
      *
      * @param list the service types not yet tested by an enclosing {@code if}
      */
@@ -105,15 +110,15 @@ public class GenerateListenerStatementNode implements Generator {
             return NodeFactory.createElseBlockNode(createToken(SyntaxKind.ELSE_KEYWORD),
                     NodeFactory.createBlockStatementNode(
                             createToken(SyntaxKind.OPEN_BRACE_TOKEN),
-                            createNodeList(buildPanicStatement()),
+                            createNodeList(buildUnrecognizedTypeErrorStatement()),
                             createToken(SyntaxKind.CLOSE_BRACE_TOKEN)));
         }
         return NodeFactory.createElseBlockNode(createToken(SyntaxKind.ELSE_KEYWORD),
                 buildIfElseChain(remaining));
     }
 
-    private StatementNode buildPanicStatement() {
+    private StatementNode buildUnrecognizedTypeErrorStatement() {
         return NodeParser.parseStatement(
-                "panic error(\"Unrecognized service type attached to the listener\");");
+                "return error(\"Unrecognized service type attached to the listener\");");
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateLogImportNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateLogImportNode.java
@@ -32,9 +32,9 @@ import static io.ballerina.compiler.syntax.tree.SyntaxKind.SLASH_TOKEN;
 /**
  * Generates the {@code import ballerina/log;} import declaration node for {@code dispatcher_service.bal}.
  *
- * <p>Required because {@code dispatcher_service.bal} emits diagnostic trace logs
- * ({@code SIGNATURE_VERIFIED}, {@code DISPATCHER_ENTERED}, {@code MATCH_LEVEL_1_*},
- * {@code MATCH_LEVEL_2_*}, {@code HANDLER_EXECUTED_*}) at each stage of request processing.
+ * <p>Required because {@code dispatcher_service.bal} logs a {@code DISPATCH_FAILED} error (with the
+ * causing error) when a dispatched callback returns an error, so an operator can see it without the
+ * failure otherwise being silently swallowed after the response has already been acknowledged.
  */
 public class GenerateLogImportNode {
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchChunkFuncNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchChunkFuncNode.java
@@ -66,7 +66,6 @@ public class GenerateMatchChunkFuncNode implements Generator {
     private final String eventIdentifierPath;
     private final String eventTypePath;
     private final boolean isHeader;
-    private final String serviceName;
 
     /**
      * Creates a generator for one channel-group match function.
@@ -79,19 +78,15 @@ public class GenerateMatchChunkFuncNode implements Generator {
      *                            no enumerable set of values (composite identifier type only), or
      *                            {@code null} for "header" and "body" identifier types
      * @param isHeader            whether the identifier type is "header" or "composite" (i.e. not "body")
-     * @param serviceName         a label identifying the generated package, embedded into the
-     *                            {@code MATCH_LEVEL_2_*} diagnostic trace log message
      */
     public GenerateMatchChunkFuncNode(HttpServiceType serviceType,
                                       String eventIdentifierPath,
                                       String eventTypePath,
-                                      boolean isHeader,
-                                      String serviceName) {
+                                      boolean isHeader) {
         this.serviceType = serviceType;
         this.eventIdentifierPath = eventIdentifierPath;
         this.eventTypePath = eventTypePath;
         this.isHeader = isHeader;
-        this.serviceName = serviceName;
     }
 
     /**
@@ -164,7 +159,7 @@ public class GenerateMatchChunkFuncNode implements Generator {
         // statement per distinct match subject (composite identifier vs. bare event type).
         GenerateMatchStatementNode matchGen =
             new GenerateMatchStatementNode(
-                List.of(serviceType), eventIdentifierPath, eventTypePath, serviceName);
+                List.of(serviceType), eventIdentifierPath, eventTypePath);
         List<StatementNode> statements = matchGen.generate();
 
         FunctionBodyBlockNode body = createFunctionBodyBlockNode(

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchRemoteFuncNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchRemoteFuncNode.java
@@ -29,7 +29,6 @@ import io.ballerina.compiler.syntax.tree.FunctionBodyBlockNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.FunctionSignatureNode;
 import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
-import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.ParameterNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.StatementNode;
@@ -91,7 +90,6 @@ public class GenerateMatchRemoteFuncNode implements Generator {
     private final List<HttpServiceType> serviceTypes;
     private final EventIdentifierConfig identifierConfig;
     private final String eventIdentifierPath;
-    private final String serviceName;
     private final List<GenerateMatchChunkFuncNode> chunkGenerators = new ArrayList<>();
 
     /**
@@ -100,17 +98,13 @@ public class GenerateMatchRemoteFuncNode implements Generator {
      * @param serviceTypes        the list of HTTP service type definitions
      * @param identifierConfig    the resolved event identifier type and path
      * @param eventIdentifierPath the expression matched against in the chunk match statements
-     * @param serviceName         a label identifying the generated package, embedded into the
-     *                            {@code MATCH_LEVEL_1_*} diagnostic trace log message
      */
     public GenerateMatchRemoteFuncNode(List<HttpServiceType> serviceTypes,
                                        EventIdentifierConfig identifierConfig,
-                                       String eventIdentifierPath,
-                                       String serviceName) {
+                                       String eventIdentifierPath) {
         this.serviceTypes = serviceTypes;
         this.identifierConfig = identifierConfig;
         this.eventIdentifierPath = eventIdentifierPath;
-        this.serviceName = serviceName;
     }
 
     /**
@@ -170,7 +164,7 @@ public class GenerateMatchRemoteFuncNode implements Generator {
         for (HttpServiceType serviceType : serviceTypes) {
             GenerateMatchChunkFuncNode chunkGen =
                     new GenerateMatchChunkFuncNode(serviceType, eventIdentifierPath,
-                            isComposite ? "eventType" : null, !isBody, serviceName);
+                            isComposite ? "eventType" : null, !isBody);
             chunkGenerators.add(chunkGen);
 
             SeparatedNodeList<FunctionArgumentNode> chunkArgs;
@@ -218,10 +212,6 @@ public class GenerateMatchRemoteFuncNode implements Generator {
                     checkExpr,
                     createToken(SEMICOLON_TOKEN));
 
-            StatementNode logStmt = NodeParser.parseStatement(String.format(
-                    "log:printDebug(\"MATCH_LEVEL_1_%s\", eventType = eventType);", serviceName));
-
-            statements.add(logStmt);
             statements.add(stmt);
         }
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchStatementNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchStatementNode.java
@@ -27,7 +27,6 @@ import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
 import io.ballerina.compiler.syntax.tree.MatchClauseNode;
 import io.ballerina.compiler.syntax.tree.MatchStatementNode;
 import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
-import io.ballerina.compiler.syntax.tree.NodeParser;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.StatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
@@ -68,7 +67,6 @@ public class GenerateMatchStatementNode implements Generator {
     private final List<HttpServiceType> serviceTypes;
     private final String eventIdentifierPath;
     private final String eventTypePath;
-    private final String serviceName;
 
     /**
      * Creates a generator for the match statement(s).
@@ -80,15 +78,12 @@ public class GenerateMatchStatementNode implements Generator {
      *                            no enumerable set of values, or {@code null} if the identifier
      *                            type never distinguishes the two (in which case every remote
      *                            function is matched against {@code eventIdentifierPath})
-     * @param serviceName         a label identifying the generated package, embedded into the
-     *                            {@code MATCH_LEVEL_2_*} diagnostic trace log message
      */
     public GenerateMatchStatementNode(List<HttpServiceType> serviceTypes, String eventIdentifierPath,
-            String eventTypePath, String serviceName) {
+            String eventTypePath) {
         this.serviceTypes = serviceTypes;
         this.eventIdentifierPath = eventIdentifierPath;
         this.eventTypePath = eventTypePath;
-        this.serviceName = serviceName;
     }
 
     @Override
@@ -160,12 +155,9 @@ public class GenerateMatchStatementNode implements Generator {
         CheckExpressionNode checkExpr = createCheckExpressionNode(SyntaxKind.CHECK_EXPRESSION,
                 createToken(SyntaxKind.CHECK_KEYWORD), methodCall);
 
-        StatementNode logStmt = NodeParser.parseStatement(String.format(
-                "log:printInfo(\"MATCH_LEVEL_2_%s\", matchedEvent = \"%s\");", serviceName, eventName));
-
         BlockStatementNode block = createBlockStatementNode(
                 createToken(SyntaxKind.OPEN_BRACE_TOKEN),
-                createNodeList(logStmt, createExpressionStatementNode(SyntaxKind.CALL_STATEMENT,
+                createNodeList(createExpressionStatementNode(SyntaxKind.CALL_STATEMENT,
                         checkExpr, createToken(SyntaxKind.SEMICOLON_TOKEN))),
                 createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
@@ -43,7 +43,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createEmptyNodeList;
 import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.createIdentifierToken;
@@ -93,17 +95,39 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
 
     private final Map.Entry<String, AsyncApiSchema> entry;
     private final Map<String, AsyncApiSchema> allSchemas;
+    private final Set<String> claimedTypeNames;
+    private final List<TypeDefinitionNode> hoistedTypes = new ArrayList<>();
 
     /**
      * Creates a generator for a single schema entry.
      *
-     * @param entry      the schema name and its definition
-     * @param allSchemas the full schema map, used to resolve {@code allOf} sub-schema stubs
+     * @param entry            the schema name and its definition
+     * @param allSchemas       the full schema map, used to resolve {@code allOf} sub-schema stubs
+     * @param claimedTypeNames the set of type names already in use across the whole generation run
+     *                         (every top-level schema name, plus every name already hoisted by any
+     *                         instance so far) - shared across every {@code GenerateModuleMemberDeclarationNode}
+     *                         instance in one {@code DataTypesGenerator} run so two different schemas
+     *                         hoisting an inline object with the same field name (e.g. two different
+     *                         payloads each with an inline {@code workflow} object) can never produce
+     *                         two colliding type definitions. Mutated in place as names are claimed.
      */
     public GenerateModuleMemberDeclarationNode(Map.Entry<String, AsyncApiSchema> entry,
-                                               Map<String, AsyncApiSchema> allSchemas) {
+                                               Map<String, AsyncApiSchema> allSchemas,
+                                               Set<String> claimedTypeNames) {
         this.entry = entry;
         this.allSchemas = allSchemas;
+        this.claimedTypeNames = claimedTypeNames;
+    }
+
+    /**
+     * Returns any additional top-level type definitions hoisted out of inline object schemas
+     * (see {@link #getTypeDescriptorNode}) while building this entry's own declaration. Only
+     * meaningful after {@link #generate()} has been called.
+     *
+     * @return the hoisted type definitions, in the order they were encountered; empty if none
+     */
+    public List<TypeDefinitionNode> getHoistedTypes() {
+        return hoistedTypes;
     }
 
     @Override
@@ -124,7 +148,7 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
         } else {
             Token anydata = AbstractNodeFactory.createIdentifierToken("anydata");
             MetadataNode metadataNode = createMetadataNode(
-                    createMarkdownDocumentationNode(createNodeList(new ArrayList<>())), createEmptyNodeList());
+                    createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
             return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
                     typeName, createBuiltinSimpleNameReferenceNode(null, anydata), createToken(SEMICOLON_TOKEN));
         }
@@ -143,12 +167,26 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                     null,                                                   // no explicit value assignment (= ...)
                     null));                                                 // no constant expression value
         }
-        return createEnumDeclarationNode(null, createToken(PUBLIC_KEYWORD), createToken(ENUM_KEYWORD),
+        MetadataNode metadataNode = createMetadataNode(
+                createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
+        return createEnumDeclarationNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(ENUM_KEYWORD),
                 typeName, createToken(OPEN_BRACE_TOKEN), createSeparatedNodeList(enums),
                 createToken(CLOSE_BRACE_TOKEN), null);
     }
 
     private TypeDefinitionNode generateRecord(IdentifierToken typeName, AsyncApiSchema schema)
+            throws GeneratorException {
+        return buildRecordTypeDefinition(typeName, schema);
+    }
+
+    /**
+     * Builds a {@code public type <name> record {...};} declaration from an object schema's
+     * properties. Shared by {@link #generateRecord} (a top-level schema entry) and
+     * {@link #getTypeDescriptorNode} (a hoisted inline object schema) - the two cases differ only
+     * in where the resulting {@link TypeDefinitionNode} ends up (returned directly vs. collected
+     * into {@link #hoistedTypes}), not in how it's built.
+     */
+    private TypeDefinitionNode buildRecordTypeDefinition(IdentifierToken typeName, AsyncApiSchema schema)
             throws GeneratorException {
         List<String> required = schema.required() != null ? schema.required() : List.of();
         NodeList<Node> fieldNodes = createNodeList(buildRecordFields(schema.properties(), required));
@@ -156,7 +194,7 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                 createToken(SyntaxKind.RECORD_KEYWORD), createToken(OPEN_BRACE_TOKEN),
                 fieldNodes, null, createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
         MetadataNode metadataNode = createMetadataNode(
-                createMarkdownDocumentationNode(createNodeList(new ArrayList<>())), createEmptyNodeList());
+                createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
         return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
                 typeName, recordType, createToken(SEMICOLON_TOKEN));
     }
@@ -187,16 +225,16 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                 createToken(SyntaxKind.RECORD_KEYWORD), createToken(OPEN_BRACE_TOKEN),
                 fieldNodes, null, createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
         MetadataNode metadataNode = createMetadataNode(
-                createMarkdownDocumentationNode(createNodeList(new ArrayList<>())), createEmptyNodeList());
+                createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
         return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
                 typeName, recordType, createToken(SEMICOLON_TOKEN));
     }
 
     private TypeDefinitionNode generateTypeAlias(IdentifierToken typeName, AsyncApiSchema schema)
             throws GeneratorException {
-        TypeDescriptorNode fieldTypeName = getTypeDescriptorNode(schema);
+        TypeDescriptorNode fieldTypeName = getTypeDescriptorNode(schema, entry.getKey());
         MetadataNode metadataNode = createMetadataNode(
-                createMarkdownDocumentationNode(createNodeList(new ArrayList<>())), createEmptyNodeList());
+                createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
         return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
                 typeName, createOptionalTypeDescriptorNode(fieldTypeName, createToken(QUESTION_MARK_TOKEN)),
                 createToken(SEMICOLON_TOKEN));
@@ -219,21 +257,12 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                 annotations = createEmptyNodeList();
             }
             IdentifierToken fieldNameToken = AbstractNodeFactory.createIdentifierToken(fieldName);
-            TypeDescriptorNode fieldType = getTypeDescriptorNode(field.getValue());
+            TypeDescriptorNode fieldType = getTypeDescriptorNode(field.getValue(), rawKey);
             boolean isOptional = !required.contains(rawKey);
             Token questionMark = isOptional ? createToken(QUESTION_MARK_TOKEN) : null;
             Token semicolon = createToken(SEMICOLON_TOKEN);
-            List<Node> fieldDoc = new ArrayList<>();
-            String docText = field.getValue().title() != null ? field.getValue().title()
-                    : field.getValue().description();
-            if (docText != null) {
-                for (String line : docText.split("\n")) {
-                    fieldDoc.add(createMarkdownDocumentationLineNode(DOCUMENTATION_DESCRIPTION,
-                            createToken(HASH_TOKEN), createNodeList(createIdentifierToken(line))));
-                }
-            }
             MetadataNode fieldMetadata = createMetadataNode(
-                    createMarkdownDocumentationNode(createNodeList(fieldDoc)), annotations);
+                    createMarkdownDocumentationNode(createNodeList(buildDocLines(field.getValue()))), annotations);
             RecordFieldNode recordField = createRecordFieldNode(fieldMetadata,
                     null, // no readonly keyword
                     fieldType, fieldNameToken, questionMark, semicolon);
@@ -242,12 +271,52 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
         return fields;
     }
 
-    private TypeDescriptorNode getTypeDescriptorNode(AsyncApiSchema schema) throws GeneratorException {
+    /**
+     * Builds the {@code #} doc-comment lines for a schema's {@code title} (preferred) or
+     * {@code description}, if either is present. Shared by both the type-level generators
+     * ({@link #generateRecord}, {@link #generateAllOfRecord}, {@link #generateTypeAlias},
+     * {@link #generateEnum}, and the {@code anydata} fallback in {@link #generate()}) and
+     * {@link #buildRecordFields}, which applies the same extraction per field.
+     *
+     * @param schema the schema whose {@code title}/{@code description} becomes the doc comment
+     * @return the doc-comment line nodes, empty if the schema has neither
+     */
+    private List<Node> buildDocLines(AsyncApiSchema schema) {
+        List<Node> docLines = new ArrayList<>();
+        String docText = schema.title() != null ? schema.title() : schema.description();
+        if (docText != null) {
+            for (String line : docText.split("\n")) {
+                docLines.add(createMarkdownDocumentationLineNode(DOCUMENTATION_DESCRIPTION,
+                        createToken(HASH_TOKEN), createNodeList(createIdentifierToken(line))));
+            }
+        }
+        return docLines;
+    }
+
+    /**
+     * Resolves the type descriptor for a field (or array-item, or type-alias) schema.
+     *
+     * <p>A schema resolved via {@code $ref} (has {@code schema.name() != null}) already has a
+     * reusable name, so it's referenced directly. An inline object schema (has {@code properties()}
+     * but no {@code $ref} name) has no such name - rather than embedding it as a long anonymous
+     * {@code record {...}} inline (the previous behavior), it's always hoisted into its own
+     * top-level named type instead, exactly like a {@code $ref}'d schema would be, so the shape of
+     * the generated code no longer depends on whether the spec author happened to extract a given
+     * object into a reusable component or left it inline - the generator no longer mirrors that
+     * spec-authoring inconsistency.
+     *
+     * @param schema   the field/item/alias-target schema to resolve
+     * @param nameHint a name to derive a hoisted type's name from if this schema turns out to be an
+     *                 inline object (typically the field key, or the array field's key for an
+     *                 array's item schema) - unused for every other case
+     */
+    private TypeDescriptorNode getTypeDescriptorNode(AsyncApiSchema schema, String nameHint)
+            throws GeneratorException {
         TypeDescriptorNode typeDesc;
         if (schema.properties() != null && !schema.properties().isEmpty()) {
-            typeDesc = buildInlineRecord(schema);
+            typeDesc = hoistInlineObject(schema, nameHint);
         } else if (schema.type() != null) {
-            typeDesc = getTypeDescriptorForPrimitive(schema);
+            typeDesc = getTypeDescriptorForPrimitive(schema, nameHint);
         } else if (schema.name() != null) {
             String typeName = CodegenUtils.getValidName(CodegenUtils.escapeIdentifier(schema.name()), true);
             typeDesc = createBuiltinSimpleNameReferenceNode(null, createIdentifierToken(typeName));
@@ -258,7 +327,8 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
         return applyNullable(schema, typeDesc);
     }
 
-    private TypeDescriptorNode getTypeDescriptorForPrimitive(AsyncApiSchema schema) throws GeneratorException {
+    private TypeDescriptorNode getTypeDescriptorForPrimitive(AsyncApiSchema schema, String nameHint)
+            throws GeneratorException {
         return switch (schema.type()) {
             case SCHEMA_TYPE_INTEGER ->
                     createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("int"));
@@ -275,10 +345,10 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
             }
             case SCHEMA_TYPE_FLOAT, SCHEMA_TYPE_DOUBLE ->
                     createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("float"));
-            case SCHEMA_TYPE_ARRAY -> getArrayTypeDescriptor(schema);
+            case SCHEMA_TYPE_ARRAY -> getArrayTypeDescriptor(schema, nameHint);
             case SCHEMA_TYPE_OBJECT -> {
                 if (schema.properties() != null && !schema.properties().isEmpty()) {
-                    yield buildInlineRecord(schema);
+                    yield hoistInlineObject(schema, nameHint);
                 }
                 yield createRecordTypeDescriptorNode(
                         AbstractNodeFactory.createIdentifierToken("record"),
@@ -290,7 +360,8 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
         };
     }
 
-    private TypeDescriptorNode getArrayTypeDescriptor(AsyncApiSchema schema) throws GeneratorException {
+    private TypeDescriptorNode getArrayTypeDescriptor(AsyncApiSchema schema, String nameHint)
+            throws GeneratorException {
         if (schema.items() == null) {
             throw new GeneratorException("Array schema is missing the 'items' attribute");
         }
@@ -298,7 +369,7 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                 createToken(OPEN_BRACKET_TOKEN), null, createToken(CLOSE_BRACKET_TOKEN));
         TypeDescriptorNode memberType;
         if (schema.items() instanceof AsyncApiSchema itemSchema) {
-            memberType = getTypeDescriptorNode(itemSchema);
+            memberType = getTypeDescriptorNode(itemSchema, nameHint + "Item");
         } else {
             memberType = createBuiltinSimpleNameReferenceNode(null,
                     AbstractNodeFactory.createIdentifierToken("anydata"));
@@ -306,22 +377,106 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
         return createArrayTypeDescriptorNode(memberType, createNodeList(dimension));
     }
 
-    private RecordTypeDescriptorNode buildInlineRecord(AsyncApiSchema schema) throws GeneratorException {
-        List<String> required = schema.required() != null ? schema.required() : List.of();
-        NodeList<Node> fieldNodes = createNodeList(buildRecordFields(schema.properties(), required));
-        return createRecordTypeDescriptorNode(
-                AbstractNodeFactory.createIdentifierToken("record"),
-                AbstractNodeFactory.createIdentifierToken("{ "),
-                fieldNodes, null,
-                AbstractNodeFactory.createIdentifierToken("} "));
+    /**
+     * Hoists an inline object schema into its own top-level {@code public type} declaration
+     * (collected into {@link #hoistedTypes}), returning a reference to it - see
+     * {@link #getTypeDescriptorNode} for why this always happens rather than embedding the object
+     * as an anonymous inline record.
+     */
+    private TypeDescriptorNode hoistInlineObject(AsyncApiSchema schema, String nameHint)
+            throws GeneratorException {
+        IdentifierToken hoistedTypeName = createIdentifierToken(resolveHoistedTypeName(nameHint));
+        hoistedTypes.add(buildRecordTypeDefinition(hoistedTypeName, schema));
+        return createBuiltinSimpleNameReferenceNode(null, hoistedTypeName);
     }
 
+    /**
+     * Names that collide with a compiler-builtin symbol even after {@link CodegenUtils#escapeIdentifier}
+     * quote-escaping (e.g. {@code 'error} is still the same symbol as {@code error} - the quote is an
+     * escape marker for using a keyword as an identifier, not a way to get a distinct name), or that
+     * are builtin symbols without being lexical keywords at all (e.g. {@code Thread} - confirmed by a
+     * real {@code bal build} rejecting a hoisted type generated with that name). Checked in addition
+     * to {@link #claimedTypeNames}, since neither {@link CodegenUtils#escapeIdentifier} nor
+     * {@link CodegenUtils#getValidName} know about this class of collision - they only reason about
+     * lexical keywords, not the compiler's builtin symbol table.
+     */
+    private static final Set<String> RESERVED_BUILTIN_TYPE_NAMES = Set.of(
+            "error", "anydata", "any", "never", "readonly", "handle", "future", "typedesc",
+            "stream", "table", "map", "record", "object", "service", "function", "var",
+            "int", "string", "boolean", "float", "decimal", "byte", "xml", "json", "thread");
+
+    /**
+     * Picks a unique type name for a newly-hoisted inline object, trying the field name itself
+     * first, then that name prefixed with the enclosing top-level schema's name, then a numeric
+     * suffix - checked and reserved against {@link #claimedTypeNames} (shared across every
+     * {@code GenerateModuleMemberDeclarationNode} instance in the run, so this can never collide
+     * with a pre-existing schema name or a type hoisted while processing a different entry) and
+     * {@link #RESERVED_BUILTIN_TYPE_NAMES}.
+     *
+     * <p>The parent-prefixed fallback is built by capitalizing the hint's first letter and
+     * concatenating it onto the raw parent name, then escaping/validating that combined string
+     * once - not by concatenating two already-escaped fragments, which can embed a leading
+     * {@code '} escape marker in the middle of the result (e.g. {@code "StatusPayload" + "'commit"}
+     * would produce the invalid identifier {@code StatusPayload'commit}). Capitalizing the hint
+     * fragment before concatenating also means the combined raw string is essentially never itself
+     * a reserved keyword even when the bare hint was (only bare {@code "commit"} is a keyword,
+     * {@code "StatusPayloadCommit"} isn't), so this naturally avoids needing the quote-escape at
+     * all in the common case, as a side effect of producing cleaner PascalCase names.
+     */
+    private String resolveHoistedTypeName(String nameHint) {
+        String candidate = buildTypeName(nameHint);
+        if (isAvailable(candidate)) {
+            claimedTypeNames.add(candidate);
+            return candidate;
+        }
+        String capitalizedHint = nameHint.isEmpty() ? nameHint
+                : nameHint.substring(0, 1).toUpperCase(Locale.ROOT) + nameHint.substring(1);
+        String parentPrefixed = buildTypeName(entry.getKey().trim() + capitalizedHint);
+        if (isAvailable(parentPrefixed)) {
+            claimedTypeNames.add(parentPrefixed);
+            return parentPrefixed;
+        }
+        int suffix = 2;
+        String numbered;
+        do {
+            numbered = parentPrefixed + suffix;
+            suffix++;
+        } while (!isAvailable(numbered));
+        claimedTypeNames.add(numbered);
+        return numbered;
+    }
+
+    private static String buildTypeName(String rawName) {
+        return CodegenUtils.getValidName(CodegenUtils.escapeIdentifier(rawName), true);
+    }
+
+    private boolean isAvailable(String candidateTypeName) {
+        return !claimedTypeNames.contains(candidateTypeName)
+                && !RESERVED_BUILTIN_TYPE_NAMES.contains(candidateTypeName.toLowerCase(Locale.ROOT))
+                && !RESERVED_BUILTIN_TYPE_NAMES.contains(
+                        candidateTypeName.replaceFirst("^'", "").toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Applies the standard AsyncAPI/OpenAPI {@code nullable} keyword by widening the type
+     * descriptor to a {@code T?} union, if the schema declares it.
+     *
+     * <p>Also checks the legacy {@code x-nullable} extension key as a fallback, in case any
+     * existing spec relies on it - real specs almost always use the standard {@code nullable}
+     * field, which {@link AsyncApiSchema#nullable()} now carries directly (see
+     * {@code SchemaMapper#mapNullable} in {@code asyncapi-core} for how it's extracted).
+     */
     private TypeDescriptorNode applyNullable(AsyncApiSchema schema, TypeDescriptorNode typeDesc) {
-        Map<String, JsonNode> extensions = schema.extensions();
-        if (extensions != null && extensions.containsKey(X_NULLABLE)
-                && "true".equals(extensions.get(X_NULLABLE).asText())) {
+        boolean nullable = Boolean.TRUE.equals(schema.nullable()) || isLegacyExtensionNullable(schema);
+        if (nullable) {
             return createOptionalTypeDescriptorNode(typeDesc, createToken(QUESTION_MARK_TOKEN));
         }
         return typeDesc;
+    }
+
+    private boolean isLegacyExtensionNullable(AsyncApiSchema schema) {
+        Map<String, JsonNode> extensions = schema.extensions();
+        return extensions != null && extensions.containsKey(X_NULLABLE)
+                && "true".equals(extensions.get(X_NULLABLE).asText());
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GeneratePostResourceFunctionNode.java
@@ -118,20 +118,15 @@ public class GeneratePostResourceFunctionNode implements Generator {
                             + " http:Response r = new; r.statusCode = http:STATUS_UNAUTHORIZED;"
                             + " check caller->respond(r); return; }"));
         }
-        statements.add(NodeParser.parseStatement("log:printInfo(\"DISPATCHER_ENTERED\");"));
         statements.add(NodeParser.parseStatement("json payload = check request.getJsonPayload();"));
         if (EventIdentifierExtractor.X_BALLERINA_EVENT_TYPE_HEADER.equals(type)) {
-            statements.add(NodeParser.parseStatement(String.format(
-                    "string eventType = check request.getHeader(\"%s\");",
-                    identifierConfig.name())));
+            statements.addAll(buildEventTypeFromHeaderStatements(identifierConfig.name()));
         } else if (EventIdentifierExtractor.X_BALLERINA_EVENT_TYPE_BODY.equals(type)) {
             statements.add(NodeParser.parseStatement(String.format(
                     "string eventType = (check payload.%s).toString();",
                     identifierConfig.path())));
         } else {
-            statements.add(NodeParser.parseStatement(String.format(
-                    "string eventType = check request.getHeader(\"%s\");",
-                    identifierConfig.name())));
+            statements.addAll(buildEventTypeFromHeaderStatements(identifierConfig.name()));
             statements.add(NodeParser.parseStatement(String.format(
                     "json|error actionField = payload.%s;",
                     identifierConfig.path())));
@@ -172,5 +167,26 @@ public class GeneratePostResourceFunctionNode implements Generator {
                 createIdentifierToken("post"),
                 createNodeList(createToken(DOT_TOKEN)),
                 signature, body);
+    }
+
+    /**
+     * Builds the statements that read {@code eventType} from a required request header, responding
+     * {@code 400 Bad Request} and returning early if it's absent - a missing header is a malformed
+     * request (client error), not a server fault, so it must not surface as a plain {@code check}
+     * failure (which the framework reports as a 500).
+     *
+     * @param headerName the request header to read (e.g. {@code "X-GitHub-Event"})
+     * @return the statements, ending with {@code eventType} bound to the header's value
+     */
+    private List<StatementNode> buildEventTypeFromHeaderStatements(String headerName) {
+        List<StatementNode> statements = new ArrayList<>();
+        statements.add(NodeParser.parseStatement(String.format(
+                "string|error eventTypeResult = request.getHeader(\"%s\");", headerName)));
+        statements.add(NodeParser.parseStatement(
+                "if eventTypeResult is error {"
+                        + " http:Response badRequest = new; badRequest.statusCode = http:STATUS_BAD_REQUEST;"
+                        + " check caller->respond(badRequest); return; }"));
+        statements.add(NodeParser.parseStatement("string eventType = eventTypeResult;"));
+        return statements;
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateVerifyWebhookSignatureFuncNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateVerifyWebhookSignatureFuncNode.java
@@ -221,7 +221,6 @@ public class GenerateVerifyWebhookSignatureFuncNode implements Generator {
                             + " return error(\"Unauthorized: Signature Mismatch\"); }"));
         }
         
-        statements.add(NodeParser.parseStatement("log:printInfo(\"SIGNATURE_VERIFIED\");"));
         statements.add(NodeParser.parseStatement("return;"));
 
         FunctionBodyBlockNode body = createFunctionBodyBlockNode(

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DataTypesGeneratorTest.java
@@ -22,6 +22,8 @@ import io.ballerina.asyncapi.generator.GeneratorException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -73,5 +75,64 @@ public class DataTypesGeneratorTest {
 
         Assert.assertFalse(result.contains("import ballerina/http;"),
                 "A schema with no properties can't need @http:Header: " + result);
+    }
+
+    @Test
+    void testGenericDataTypeUnionOrdersLooseSchemasLast() throws GeneratorException {
+        // "Installation" (all fields optional) declared FIRST, "PushPayload" (a required field)
+        // declared SECOND - a LinkedHashMap so schemas.entrySet() iterates in this exact order,
+        // which is deliberately the wrong order for the union: without the ordering fix, the loose
+        // schema would stay first, at real risk of capturing payloads meant for concrete types via
+        // cloneWithType's first-match resolution. The generator must reorder it to last regardless
+        // of input order.
+        AsyncApiSchema installation = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of(
+                        "id", AsyncApiSchema.builder().type("integer").build(),
+                        "node_id", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema pushPayload = AsyncApiSchema.builder()
+                .type("object")
+                .required(List.of("ref"))
+                .properties(Map.of("ref", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        Map<String, AsyncApiSchema> schemas = new LinkedHashMap<>();
+        schemas.put("Installation", installation);
+        schemas.put("PushPayload", pushPayload);
+
+        String result = new DataTypesGenerator(schemas, Optional.empty()).generate();
+
+        int unionStart = result.indexOf("public type GenericDataType");
+        Assert.assertTrue(unionStart >= 0, "Expected a GenericDataType union declaration: " + result);
+        String unionDecl = result.substring(unionStart, result.indexOf(';', unionStart));
+        Assert.assertTrue(unionDecl.indexOf("PushPayload") < unionDecl.indexOf("Installation"),
+                "The loose 'Installation' schema must be ordered after the concrete 'PushPayload' "
+                        + "schema in the union, regardless of input order: " + unionDecl);
+    }
+
+    @Test
+    void testGenericDataTypeUnionKeepsRequiredFieldSchemasBeforeEachOtherInOriginalOrder() throws GeneratorException {
+        // Two concrete (non-loose) schemas should keep their relative order - the ordering fix
+        // should only ever move loose schemas to the end, not reorder everything else.
+        AsyncApiSchema first = AsyncApiSchema.builder()
+                .type("object")
+                .required(List.of("a"))
+                .properties(Map.of("a", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema second = AsyncApiSchema.builder()
+                .type("object")
+                .required(List.of("b"))
+                .properties(Map.of("b", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        Map<String, AsyncApiSchema> schemas = new LinkedHashMap<>();
+        schemas.put("FirstPayload", first);
+        schemas.put("SecondPayload", second);
+
+        String result = new DataTypesGenerator(schemas, Optional.empty()).generate();
+
+        int unionStart = result.indexOf("public type GenericDataType");
+        String unionDecl = result.substring(unionStart, result.indexOf(';', unionStart));
+        Assert.assertTrue(unionDecl.indexOf("FirstPayload") < unionDecl.indexOf("SecondPayload"),
+                "Two concrete schemas should keep their original relative order: " + unionDecl);
     }
 }

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
@@ -44,8 +44,7 @@ public class DispatcherGeneratorTest {
     @Test
     void testGenerateWithBodyIdentifier() throws GeneratorException {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
-        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
-                "test_service").generate();
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty()).generate();
 
         Assert.assertFalse(source.isBlank(), "Generated dispatcher source should not be blank");
         Assert.assertTrue(source.contains("DispatcherService"),
@@ -59,10 +58,29 @@ public class DispatcherGeneratorTest {
     }
 
     @Test
+    void testDiagnosticTraceLogsRemovedButDispatchFailedKept() throws GeneratorException {
+        // MATCH_LEVEL_1_*/MATCH_LEVEL_2_*/DISPATCHER_ENTERED/SIGNATURE_VERIFIED/HANDLER_EXECUTED_*
+        // were pure diagnostic trace noise with no value to an end user - removed. DISPATCH_FAILED
+        // is a real error signal (includes the causing error) and must stay.
+        EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty())
+                .generate();
+
+        Assert.assertTrue(source.contains("DISPATCH_FAILED"),
+                "DISPATCH_FAILED is a real error signal and must be kept: " + source);
+        Assert.assertFalse(source.contains("MATCH_LEVEL"), "MATCH_LEVEL_1/2 trace logs should be removed: " + source);
+        Assert.assertFalse(source.contains("DISPATCHER_ENTERED"),
+                "DISPATCHER_ENTERED trace log should be removed: " + source);
+        Assert.assertFalse(source.contains("HANDLER_EXECUTED"),
+                "HANDLER_EXECUTED trace log should be removed: " + source);
+        Assert.assertTrue(source.contains("invokeRemoteFunction"),
+                "The real remote-function invocation must survive removing its log wrapper: " + source);
+    }
+
+    @Test
     void testGenerateWithHeaderIdentifier() throws GeneratorException {
         EventIdentifierConfig config = new EventIdentifierConfig("header", "X-Event-Type", null);
-        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
-                "test_service").generate();
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty()).generate();
 
         Assert.assertFalse(source.isBlank(), "Generated dispatcher source should not be blank");
         Assert.assertTrue(source.contains("DispatcherService"),
@@ -74,8 +92,7 @@ public class DispatcherGeneratorTest {
     @Test
     void testGenerateWithCompositeIdentifier() throws GeneratorException {
         EventIdentifierConfig config = new EventIdentifierConfig("composite", "X-GitHub-Event", "action");
-        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
-                "test_service").generate();
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty()).generate();
 
         Assert.assertFalse(source.isBlank(), "Generated dispatcher source should not be blank");
         Assert.assertTrue(source.contains("DispatcherService"),
@@ -89,10 +106,36 @@ public class DispatcherGeneratorTest {
     }
 
     @Test
+    void testMissingRequiredHeaderRespondsBadRequestNotPlainCheck() throws GeneratorException {
+        // A missing required header (X-GitHub-Event, X-Event-Type, etc.) is a malformed request -
+        // a client error, not a server fault - so it must produce an explicit 400 response instead
+        // of propagating via a bare `check`, which the framework would report as a 500. Covers both
+        // identifier types that read a header ("header" and "composite").
+        EventIdentifierConfig headerConfig = new EventIdentifierConfig("header", "X-Event-Type", null);
+        String headerSource = new DispatcherGenerator(SINGLE_SERVICE, headerConfig, Optional.<WebhookAuthConfig>empty())
+                .generate();
+        assertRespondsBadRequestOnMissingHeader(headerSource);
+
+        EventIdentifierConfig compositeConfig = new EventIdentifierConfig("composite", "X-GitHub-Event", "action");
+        String compositeSource = new DispatcherGenerator(SINGLE_SERVICE, compositeConfig,
+                Optional.<WebhookAuthConfig>empty()).generate();
+        assertRespondsBadRequestOnMissingHeader(compositeSource);
+    }
+
+    private void assertRespondsBadRequestOnMissingHeader(String source) {
+        Assert.assertFalse(source.contains("check request.getHeader"),
+                "The header read must not be a bare check - a missing header must be handled "
+                        + "explicitly, not propagated as a 500: " + source);
+        Assert.assertTrue(source.contains("string|error eventTypeResult = request.getHeader"),
+                "The header read should be captured as string|error: " + source);
+        Assert.assertTrue(source.contains("http:STATUS_BAD_REQUEST"),
+                "A missing header should respond 400, not fall through to a 500: " + source);
+    }
+
+    @Test
     void testAckSentBeforeDispatchAndDispatchErrorsAreNotPropagated() throws GeneratorException {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
-        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
-                "test_service").generate();
+        String source = new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty()).generate();
 
         int ackIndex = source.indexOf("ackResponse.statusCode = http:STATUS_OK;");
         int dispatchIndex = source.indexOf("error? dispatchResult =");
@@ -115,7 +158,7 @@ public class DispatcherGeneratorTest {
     void testEmptyServiceTypesThrows() {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
         try {
-            new DispatcherGenerator(List.of(), config, Optional.<WebhookAuthConfig>empty(), "test_service").generate();
+            new DispatcherGenerator(List.of(), config, Optional.<WebhookAuthConfig>empty()).generate();
             Assert.fail("Expected GeneratorException for empty service types list");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");
@@ -126,7 +169,7 @@ public class DispatcherGeneratorTest {
     void testNullServiceTypesThrows() {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
         try {
-            new DispatcherGenerator(null, config, Optional.<WebhookAuthConfig>empty(), "test_service").generate();
+            new DispatcherGenerator(null, config, Optional.<WebhookAuthConfig>empty()).generate();
             Assert.fail("Expected GeneratorException for null service types");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");
@@ -137,8 +180,7 @@ public class DispatcherGeneratorTest {
     void testInvalidIdentifierTypeThrows() {
         EventIdentifierConfig config = new EventIdentifierConfig("unknown", null, "event.type");
         try {
-            new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty(),
-                    "test_service").generate();
+            new DispatcherGenerator(SINGLE_SERVICE, config, Optional.<WebhookAuthConfig>empty()).generate();
             Assert.fail("Expected GeneratorException for unsupported identifier type");
         } catch (GeneratorException e) {
             Assert.assertTrue(e.getMessage().contains("unknown") || e.getMessage().contains("Unsupported"),

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
@@ -43,7 +43,8 @@ public class ListenerGeneratorTest {
                         new HttpRemoteFunction("issues.opened", "IssueEvent")
                 ))
         );
-        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty()).generate();
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty(), "Test Connector")
+                .generate();
 
         Assert.assertFalse(source.isBlank(), "Generated listener source should not be blank");
         Assert.assertTrue(source.contains("Listener"),
@@ -59,6 +60,24 @@ public class ListenerGeneratorTest {
     }
 
     @Test
+    void testGenerateUsesSpecTitleAsDisplayLabelAndIncludesIconPath() throws GeneratorException {
+        // The @display annotation must carry a real label (from the spec's info.title) and an
+        // iconPath - previously both were hardcoded blank/absent, leaving the class unlabeled and
+        // iconless in any visual/low-code tooling that reads @display.
+        List<HttpServiceType> serviceTypes = List.of(
+                new HttpServiceType("RepositoryService", List.of(
+                        new HttpRemoteFunction("push", "PushEvent")
+                ))
+        );
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty(), "GitHub Webhooks API")
+                .generate();
+
+        Assert.assertTrue(source.contains("@display {label: \"GitHub Webhooks API\", iconPath: \"icon.png\"}"),
+                "The Listener class should carry the spec's title as its display label and a real "
+                        + "iconPath: " + source);
+    }
+
+    @Test
     void testGetServiceTypeStrReturnsErrorInsteadOfPanicking() throws GeneratorException {
         // An unrecognized service type must fail as an ordinary error the caller can check/handle,
         // not a panic that crashes the whole running listener over one bad attach() call.
@@ -67,7 +86,8 @@ public class ListenerGeneratorTest {
                         new HttpRemoteFunction("push", "PushEvent")
                 ))
         );
-        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty()).generate();
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty(), "Test Connector")
+                .generate();
 
         Assert.assertFalse(source.contains("panic"),
                 "getServiceTypeStr must not panic on an unrecognized service type: " + source);
@@ -82,7 +102,7 @@ public class ListenerGeneratorTest {
     @Test
     void testEmptyServiceTypesThrows() {
         try {
-            new ListenerGenerator(List.of(), Optional.<WebhookAuthConfig>empty()).generate();
+            new ListenerGenerator(List.of(), Optional.<WebhookAuthConfig>empty(), "Test Connector").generate();
             Assert.fail("Expected GeneratorException for empty service types list");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");
@@ -92,7 +112,7 @@ public class ListenerGeneratorTest {
     @Test
     void testNullServiceTypesThrows() {
         try {
-            new ListenerGenerator(null, Optional.<WebhookAuthConfig>empty()).generate();
+            new ListenerGenerator(null, Optional.<WebhookAuthConfig>empty(), "Test Connector").generate();
             Assert.fail("Expected GeneratorException for null service types");
         } catch (GeneratorException e) {
             Assert.assertNotNull(e.getMessage(), "Exception message should not be null");

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ListenerGeneratorTest.java
@@ -59,6 +59,27 @@ public class ListenerGeneratorTest {
     }
 
     @Test
+    void testGetServiceTypeStrReturnsErrorInsteadOfPanicking() throws GeneratorException {
+        // An unrecognized service type must fail as an ordinary error the caller can check/handle,
+        // not a panic that crashes the whole running listener over one bad attach() call.
+        List<HttpServiceType> serviceTypes = List.of(
+                new HttpServiceType("RepositoryService", List.of(
+                        new HttpRemoteFunction("push", "PushEvent")
+                ))
+        );
+        String source = new ListenerGenerator(serviceTypes, Optional.<WebhookAuthConfig>empty()).generate();
+
+        Assert.assertFalse(source.contains("panic"),
+                "getServiceTypeStr must not panic on an unrecognized service type: " + source);
+        Assert.assertTrue(source.contains("returns string|error"),
+                "getServiceTypeStr's return type must be string|error, not plain string: " + source);
+        Assert.assertTrue(source.contains("return error(\"Unrecognized service type attached to the listener\")"),
+                "The terminal else branch should return an error: " + source);
+        Assert.assertTrue(source.contains("check self.getServiceTypeStr(serviceRef)"),
+                "attach/detach must propagate getServiceTypeStr's error via check: " + source);
+    }
+
+    @Test
     void testEmptyServiceTypesThrows() {
         try {
             new ListenerGenerator(List.of(), Optional.<WebhookAuthConfig>empty()).generate();

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNodeTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNodeTest.java
@@ -1,0 +1,308 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.asyncapi.generator.http.node;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.ballerina.asyncapi.core.model.component.AsyncApiSchema;
+import io.ballerina.asyncapi.generator.GeneratorException;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link GenerateModuleMemberDeclarationNode}'s type-level doc-comment generation
+ * (record, allOf record, type alias, enum, and the anydata fallback), mirroring the field-level
+ * doc-comment coverage that already exists implicitly via other tests.
+ */
+public class GenerateModuleMemberDeclarationNodeTest {
+
+    private String generate(String schemaName, AsyncApiSchema schema) throws GeneratorException {
+        return generate(schemaName, schema, Map.of(schemaName, schema));
+    }
+
+    /**
+     * Same as {@link #generate(String, AsyncApiSchema)}, but lets a test supply a richer
+     * {@code allSchemas} map - needed for hoisting-collision tests, where the candidate hoisted
+     * name must be checked against a pre-existing top-level schema.
+     */
+    private String generate(String schemaName, AsyncApiSchema schema, Map<String, AsyncApiSchema> allSchemas)
+            throws GeneratorException {
+        GenerateModuleMemberDeclarationNode gen = new GenerateModuleMemberDeclarationNode(
+                Map.entry(schemaName, schema), allSchemas, new HashSet<>(allSchemas.keySet()));
+        StringBuilder result = new StringBuilder(gen.generate().toString());
+        for (TypeDefinitionNode hoisted : gen.getHoistedTypes()) {
+            result.append(hoisted);
+        }
+        return result.toString();
+    }
+
+    @Test
+    void testRecordWithTitleGetsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .title("A GitHub Actions workflow run")
+                .properties(Map.of("id", AsyncApiSchema.builder().type("integer").build()))
+                .build();
+        String result = generate("WorkflowRun", schema);
+        Assert.assertTrue(result.contains("#A GitHub Actions workflow run"),
+                "Record type should carry its title as a doc comment: " + result);
+    }
+
+    @Test
+    void testRecordWithDescriptionOnlyGetsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .description("Payload for push events")
+                .properties(Map.of("ref", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        String result = generate("PushPayload", schema);
+        Assert.assertTrue(result.contains("#Payload for push events"),
+                "Record type should fall back to description when title is absent: " + result);
+    }
+
+    @Test
+    void testRecordWithNeitherTitleNorDescriptionOmitsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("id", AsyncApiSchema.builder().type("integer").build()))
+                .build();
+        String result = generate("Bare", schema);
+        Assert.assertFalse(result.contains("#"),
+                "Record type with neither title nor description should have no doc comment: " + result);
+    }
+
+    @Test
+    void testAllOfRecordWithTitleGetsDocComment() throws GeneratorException {
+        AsyncApiSchema sub = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("id", AsyncApiSchema.builder().type("integer").build()))
+                .build();
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .title("Merged event shape")
+                .allOf(List.of(sub))
+                .build();
+        String result = generate("MergedEvent", schema);
+        Assert.assertTrue(result.contains("#Merged event shape"),
+                "allOf-merged record should carry the outer schema's title as a doc comment: " + result);
+    }
+
+    @Test
+    void testTypeAliasWithTitleGetsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("string")
+                .title("An opaque identifier")
+                .build();
+        String result = generate("OpaqueId", schema);
+        Assert.assertTrue(result.contains("#An opaque identifier"),
+                "Type alias should carry its title as a doc comment: " + result);
+    }
+
+    @Test
+    void testEnumWithTitleGetsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .title("The action that was performed")
+                .enumValue(List.of(new TextNode("created"), new TextNode("deleted")))
+                .build();
+        String result = generate("ActionEnum", schema);
+        Assert.assertTrue(result.contains("#The action that was performed"),
+                "Enum type should carry its title as a doc comment: " + result);
+    }
+
+    @Test
+    void testAnydataFallbackWithTitleGetsDocComment() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .title("Unstructured payload data")
+                .build();
+        String result = generate("Unstructured", schema);
+        Assert.assertTrue(result.contains("#Unstructured payload data"),
+                "The anydata-fallback branch should also carry a title as a doc comment: " + result);
+    }
+
+    @Test
+    void testInlineObjectFieldIsHoistedIntoNamedType() throws GeneratorException {
+        // WorkflowRunPayload.workflow, mirroring the real spec: an inline object (no $ref/name)
+        // that should now become its own named type instead of a long anonymous inline record.
+        AsyncApiSchema workflow = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of(
+                        "id", AsyncApiSchema.builder().type("integer").build(),
+                        "name", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema payload = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("workflow", workflow))
+                .build();
+        String result = generate("WorkflowRunPayload", payload);
+
+        Assert.assertTrue(result.contains("Workflowworkflow?;"),
+                "The field should reference a named 'Workflow' type, not an inline record: " + result);
+        Assert.assertTrue(result.contains("publictypeWorkflowrecord"),
+                "A top-level 'Workflow' type definition should be hoisted out: " + result);
+    }
+
+    @Test
+    void testHoistedTypeNameCollisionIsDisambiguatedWithParentPrefix() throws GeneratorException {
+        // A pre-existing top-level schema already named "Workflow" - the naive hoisted name would
+        // collide with it, so the hoister must fall back to a parent-prefixed name instead.
+        AsyncApiSchema existingWorkflow = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("id", AsyncApiSchema.builder().type("integer").build()))
+                .build();
+        AsyncApiSchema inlineWorkflow = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("name", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema payload = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("workflow", inlineWorkflow))
+                .build();
+        Map<String, AsyncApiSchema> allSchemas = Map.of(
+                "Workflow", existingWorkflow,
+                "WorkflowRunPayload", payload);
+
+        String result = generate("WorkflowRunPayload", payload, allSchemas);
+
+        Assert.assertTrue(result.contains("WorkflowRunPayloadWorkflowworkflow?;"),
+                "On a name collision, the hoisted type should be disambiguated with the parent's "
+                        + "name as a prefix: " + result);
+    }
+
+    @Test
+    void testHoistedTypeNameCollisionOnKeywordDoesNotEmbedStrayQuote() throws GeneratorException {
+        // Real bug found via a live regen: "commit" is a Ballerina keyword, so the bare candidate
+        // name escapes to 'commit. When a second, different parent's inline "commit" field collides
+        // with that already-claimed name, the parent-prefixed fallback must NOT concatenate the
+        // pre-escaped "'commit" onto the parent name (producing the invalid identifier
+        // "StatusPayload'commit") - it must capitalize+concatenate the RAW hint first, then escape
+        // the combined string once, giving the valid "StatusPayloadCommit".
+        AsyncApiSchema firstCommit = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("sha", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema firstParent = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("commit", firstCommit))
+                .build();
+        AsyncApiSchema secondCommit = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("sha", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema secondParent = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("commit", secondCommit))
+                .build();
+        Map<String, AsyncApiSchema> allSchemas = new LinkedHashMap<>();
+        allSchemas.put("BranchesItem", firstParent);
+        allSchemas.put("StatusPayload", secondParent);
+        Set<String> claimedTypeNames = new HashSet<>(allSchemas.keySet());
+
+        StringBuilder combined = new StringBuilder();
+        for (Map.Entry<String, AsyncApiSchema> entry : allSchemas.entrySet()) {
+            GenerateModuleMemberDeclarationNode gen =
+                    new GenerateModuleMemberDeclarationNode(entry, allSchemas, claimedTypeNames);
+            combined.append(gen.generate());
+            for (TypeDefinitionNode hoisted : gen.getHoistedTypes()) {
+                combined.append(hoisted);
+            }
+        }
+        String result = combined.toString();
+
+        // The exact corrupted type name the real bug produced - "public type" immediately
+        // followed by a name with an embedded quote is unambiguous (an escaped identifier only
+        // ever appears as a complete standalone token, e.g. field name 'commit, never fused into
+        // a type declaration's own name like this).
+        Assert.assertFalse(result.contains("publictypeStatusPayload'commitrecord"),
+                "The type name must never have a stray escape-quote embedded in the middle: " + result);
+        Assert.assertTrue(result.contains("publictype'commitrecord"),
+                "The first 'commit' field should hoist to the escaped bare keyword name: " + result);
+        Assert.assertTrue(result.contains("publictypeStatusPayloadCommitrecord"),
+                "The second, colliding 'commit' field must fall back to a clean parent-prefixed "
+                        + "name, not an invalid identifier with an embedded quote: " + result);
+    }
+
+    @Test
+    void testHoistedTypeNameAvoidsBuiltinSymbolCollision() throws GeneratorException {
+        // Real bug found via a live regen: an inline "thread" field naively hoists to "Thread",
+        // which is a Ballerina compiler-builtin symbol - bal build rejected it as "redeclared
+        // builtin symbol 'Thread'" even though "thread" isn't a lexical keyword (escapeIdentifier
+        // has no reason to touch it). The hoister must recognize this collision on its own and fall
+        // back to the parent-prefixed name instead.
+        AsyncApiSchema thread = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("node_id", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema payload = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("thread", thread))
+                .build();
+        String result = generate("PullRequestReviewThreadPayload", payload);
+
+        Assert.assertFalse(result.contains("publictypeThreadrecord"),
+                "Must not hoist a bare 'Thread' type - it collides with the compiler builtin: " + result);
+        Assert.assertTrue(result.contains("publictypePullRequestReviewThreadPayloadThreadrecord"),
+                "Should fall back to the parent-prefixed name instead: " + result);
+    }
+
+    @Test
+    void testArrayItemInlineObjectIsHoisted() throws GeneratorException {
+        AsyncApiSchema item = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("name", AsyncApiSchema.builder().type("string").build()))
+                .build();
+        AsyncApiSchema arraySchema = AsyncApiSchema.builder()
+                .type("array")
+                .items(item)
+                .build();
+        AsyncApiSchema payload = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("labels", arraySchema))
+                .build();
+        String result = generate("LabeledPayload", payload);
+
+        Assert.assertTrue(result.contains("LabelsItem[]labels"),
+                "The array's inline item schema should be hoisted and referenced by name: " + result);
+        Assert.assertTrue(result.contains("publictypeLabelsItemrecord"),
+                "A top-level 'LabelsItem' type definition should be hoisted out for the array item: "
+                        + result);
+    }
+
+    @Test
+    void testStandardNullableFieldBecomesOptionalType() throws GeneratorException {
+        // The standard AsyncAPI 'nullable' keyword (schema.nullable(), as opposed to the legacy
+        // x-nullable extension) must widen the field's type to T? - this is what a real spec author
+        // actually writes (confirmed: docs/spec/asyncapi.yml uses plain "nullable: true").
+        AsyncApiSchema nullableField = AsyncApiSchema.builder().type("string").nullable(true).build();
+        AsyncApiSchema nonNullableField = AsyncApiSchema.builder().type("string").build();
+        AsyncApiSchema payload = AsyncApiSchema.builder()
+                .type("object")
+                .properties(Map.of("starredAt", nullableField, "action", nonNullableField))
+                .build();
+        String result = generate("StarPayload", payload);
+
+        Assert.assertTrue(result.contains("string?starredAt"),
+                "A field with nullable() == true should get a T? type: " + result);
+        Assert.assertTrue(result.contains("stringaction"),
+                "A field without 'nullable' should keep its plain type: " + result);
+    }
+}

--- a/asyncapi-generator/src/test/resources/testng.xml
+++ b/asyncapi-generator/src/test/resources/testng.xml
@@ -18,6 +18,7 @@
             <class name="io.ballerina.asyncapi.generator.http.extractor.EventIdentifierExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.ServiceTypeExtractorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.extractor.SchemaExtractorTest"/>
+            <class name="io.ballerina.asyncapi.generator.http.node.GenerateModuleMemberDeclarationNodeTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.ListenerGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.DataTypesGeneratorTest"/>
             <class name="io.ballerina.asyncapi.generator.http.generator.DispatcherGeneratorTest"/>


### PR DESCRIPTION
## Summary

Fixes https://github.com/ballerina-platform/ballerina-library/issues/9042.

**New generator behaviors**
- Type-level doc comments on generated `record`, `allOf`-based record, type-alias, and `enum` declarations (previously only field-level doc comments were generated).
- Always hoist inline object schemas into named top-level types, with collision handling for schemas that independently hoist a same-named inline field.
- Removed diagnostic trace logs (`MATCH_LEVEL_1`, `MATCH_LEVEL_2`, `DISPATCHER_ENTERED`, `SIGNATURE_VERIFIED`, `HANDLER_EXECUTED_*`) from generated services; kept `DISPATCH_FAILED`, a genuine error signal.

**Permanent fixes for previously hand-patched bugs**
1. Nullable fields — read the standard AsyncAPI/JSON Schema `nullable` keyword (including via `$ref` + sibling `nullable`) instead of a nonstandard `X_NULLABLE` extension key.
2. `getServiceTypeStr` — returns `string|error` and lets `attach`/`detach` propagate via `check`, instead of panicking on an unrecognized service type.
3. `GenericDataType` union member ordering — "loose" schemas (no required fields) now sort to the end of the union, avoiding incorrect `cloneWithType` matches.
4. Missing event-identifier header — generated dispatcher now returns an explicit HTTP 400 instead of panicking via a bare `check`.

## Test plan

- [x] `./gradlew :asyncapi-generator:check` — 357 tests passing, checkstyle clean.
- [x] `./gradlew :asyncapi-core:check` — passing.
- [x] Real regen of `module-ballerinax-github.trigger` from this generator, followed by `bal build` + `bal test` (265/265 passing), confirming all four bugs above are correct without any hand-patching.