### PR TITLE
Feature/event type display name

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/DispatchTestCaseExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/DispatchTestCaseExtractor.java
@@ -42,6 +42,7 @@ import java.util.Map;
 public final class DispatchTestCaseExtractor {
 
     private static final String X_BALLERINA_EVENT_TYPE = "x-ballerina-event-type";
+    private static final String X_BALLERINA_EVENT_LABEL = "x-ballerina-event-label";
     private static final String X_BALLERINA_SERVICE_TYPE = "x-ballerina-service-type";
 
     private final AsyncApiSpec asyncApiSpec;
@@ -97,6 +98,9 @@ public final class DispatchTestCaseExtractor {
                 if (eventIdentifier.isBlank()) {
                     continue;
                 }
+                JsonNode labelNode = extensions.get(X_BALLERINA_EVENT_LABEL);
+                String displayLabel = labelNode != null && !labelNode.asText().isBlank()
+                        ? labelNode.asText() : null;
                 String headerValue = message.name() != null && !message.name().isBlank()
                         ? message.name()
                         : eventIdentifier;
@@ -110,7 +114,8 @@ public final class DispatchTestCaseExtractor {
                 payloadTypeName = CodegenUtils.getValidName(
                         CodegenUtils.escapeIdentifier(payloadTypeName.trim()), true);
 
-                String functionName = CodegenUtils.getFunctionNameByEventName(eventIdentifier);
+                String namingBasis = displayLabel != null ? displayLabel : eventIdentifier;
+                String functionName = CodegenUtils.getFunctionNameByEventName(namingBasis);
                 String serviceTypeDeclName = CodegenUtils.getServiceTypeNameByServiceName(serviceTypeName);
                 testCases.add(new DispatchTestCase(
                         serviceTypeDeclName, functionName, eventIdentifier, headerValue, payloadTypeName));

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ServiceTypeExtractor.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/extractor/ServiceTypeExtractor.java
@@ -42,6 +42,7 @@ import java.util.Map;
 public final class ServiceTypeExtractor {
 
     public static final String X_BALLERINA_EVENT_TYPE = "x-ballerina-event-type";
+    private static final String X_BALLERINA_EVENT_LABEL = "x-ballerina-event-label";
     private static final String X_BALLERINA_SERVICE_TYPE = "x-ballerina-service-type";
 
     private final AsyncApiSpec asyncApiSpec;
@@ -132,6 +133,9 @@ public final class ServiceTypeExtractor {
                 AsyncApiMessage message = msgEntry.getValue();
                 validateMessage(message, messageId, operationChannel.address());
                 String eventType = message.extensions().get(X_BALLERINA_EVENT_TYPE).asText();
+                JsonNode labelNode = message.extensions().get(X_BALLERINA_EVENT_LABEL);
+                String displayLabel = labelNode != null && !labelNode.asText().isBlank()
+                        ? labelNode.asText() : null;
                 Object payload = message.payload();
                 String payloadTypeName = eventType;
                 boolean matchOnEventType = false;
@@ -145,7 +149,7 @@ public final class ServiceTypeExtractor {
                     matchOnEventType = hasFreeFormActionField(schema);
                 }
                 serviceTypeMap.get(serviceTypeName).remoteFunctions()
-                        .add(new HttpRemoteFunction(eventType, payloadTypeName, matchOnEventType));
+                        .add(new HttpRemoteFunction(eventType, payloadTypeName, matchOnEventType, displayLabel));
             }
         }
 

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/HttpRemoteFunction.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/model/HttpRemoteFunction.java
@@ -31,8 +31,17 @@ package io.ballerina.asyncapi.generator.http.model;
  *                         composite literal at generation time. Always {@code false} for
  *                         {@code "header"} and {@code "body"} identifier types, where no composite
  *                         identifier is ever built.
+ * @param displayLabel     an optional, human-friendlier string (from a message's
+ *                         {@code x-ballerina-event-label} extension) to derive the generated
+ *                         function name and doc comment from instead of {@code functionName}.
+ *                         Exists for cases where the real wire-matching value makes an awkward
+ *                         function name (e.g. a versioned, prefixed CloudEvents type string like
+ *                         {@code "qbo.account.merged.v1"}). {@code null} preserves the pre-existing
+ *                         behavior of deriving the name from {@code functionName} itself; the match
+ *                         clause always compares against {@code functionName}, never this label.
  */
-public record HttpRemoteFunction(String functionName, String eventType, boolean matchOnEventType) {
+public record HttpRemoteFunction(String functionName, String eventType, boolean matchOnEventType,
+        String displayLabel) {
 
     /**
      * Creates a remote function that matches on the composite identifier (the pre-existing
@@ -42,6 +51,17 @@ public record HttpRemoteFunction(String functionName, String eventType, boolean 
      * @param eventType    the schema type reference for the event payload
      */
     public HttpRemoteFunction(String functionName, String eventType) {
-        this(functionName, eventType, false);
+        this(functionName, eventType, false, null);
+    }
+
+    /**
+     * Creates a remote function with no display label override (the pre-existing behavior).
+     *
+     * @param functionName     the Ballerina-safe function name derived from the event name
+     * @param eventType        the schema type reference for the event payload
+     * @param matchOnEventType see the class-level parameter doc
+     */
+    public HttpRemoteFunction(String functionName, String eventType, boolean matchOnEventType) {
+        this(functionName, eventType, matchOnEventType, null);
     }
 }

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchStatementNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateMatchStatementNode.java
@@ -104,7 +104,7 @@ public class GenerateMatchStatementNode implements Generator {
         List<MatchClauseNode> eventTypeClauses = new ArrayList<>();
         for (HttpServiceType service : serviceTypes) {
             for (HttpRemoteFunction fn : service.remoteFunctions()) {
-                MatchClauseNode clause = generateMatchClause(service.serviceTypeName(), fn.functionName());
+                MatchClauseNode clause = generateMatchClause(service.serviceTypeName(), fn);
                 if (eventTypePath != null && fn.matchOnEventType()) {
                     eventTypeClauses.add(clause);
                 } else {
@@ -132,8 +132,10 @@ public class GenerateMatchStatementNode implements Generator {
                 createToken(SyntaxKind.CLOSE_BRACE_TOKEN), null);
     }
 
-    private MatchClauseNode generateMatchClause(String serviceTypeName, String eventName) {
-        String funcName = CodegenUtils.getFunctionNameByEventName(eventName);
+    private MatchClauseNode generateMatchClause(String serviceTypeName, HttpRemoteFunction fn) {
+        String eventName = fn.functionName();
+        String namingBasis = fn.displayLabel() != null ? fn.displayLabel() : fn.functionName();
+        String funcName = CodegenUtils.getFunctionNameByEventName(namingBasis);
         String resolvedServiceTypeName = CodegenUtils.getServiceTypeNameByServiceName(serviceTypeName);
 
         SeparatedNodeList<FunctionArgumentNode> args = createSeparatedNodeList(

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateServiceTypeNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateServiceTypeNode.java
@@ -101,11 +101,12 @@ public class GenerateServiceTypeNode implements Generator {
                     null, createIdentifierToken(eventType));
             List<Node> params = new ArrayList<>();
             params.add(createRequiredParameterNode(createEmptyNodeList(), typeNode, createIdentifierToken("payload")));
+            String namingBasis = fn.displayLabel() != null ? fn.displayLabel() : fn.functionName();
             MethodDeclarationNode method = createMethodDeclarationNode(
                     SyntaxKind.METHOD_DECLARATION, null,
                     createNodeList(createToken(REMOTE_KEYWORD)),
                     createToken(SyntaxKind.FUNCTION_KEYWORD),
-                    createIdentifierToken(CodegenUtils.getFunctionNameByEventName(fn.functionName())),
+                    createIdentifierToken(CodegenUtils.getFunctionNameByEventName(namingBasis)),
                     createEmptyNodeList(),
                     createFunctionSignatureNode(
                             createToken(OPEN_PAREN_TOKEN), createSeparatedNodeList(params),

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/DispatcherGeneratorTest.java
@@ -89,6 +89,23 @@ public class DispatcherGeneratorTest {
     }
 
     @Test
+    void testDisplayLabelDoesNotLeakIntoMatchClauseLiteral() throws GeneratorException {
+        List<HttpServiceType> serviceTypes = List.of(
+                new HttpServiceType("AccountService", List.of(
+                        new HttpRemoteFunction("qbo.account.merged.v1", "QuickBookEvent", false, "AccountMerged")
+                ))
+        );
+        EventIdentifierConfig config = new EventIdentifierConfig("body", null, "type");
+        String source = new DispatcherGenerator(serviceTypes, config, Optional.<WebhookAuthConfig>empty(),
+                "test_service").generate();
+
+        Assert.assertTrue(source.contains("qbo.account.merged.v1"),
+                "The match clause must still compare against the real wire event type, not the display label");
+        Assert.assertTrue(source.contains("onAccountMerged"),
+                "The dispatched remote function call should use the display-label-derived function name");
+    }
+
+    @Test
     void testEmptyServiceTypesThrows() {
         EventIdentifierConfig config = new EventIdentifierConfig("body", null, "event.type");
         try {

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ServiceTypesGeneratorTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/generator/ServiceTypesGeneratorTest.java
@@ -80,6 +80,23 @@ public class ServiceTypesGeneratorTest {
     }
 
     @Test
+    void testDisplayLabelOverridesGeneratedFunctionName() throws GeneratorException {
+        List<HttpRemoteFunction> fns = List.of(
+                new HttpRemoteFunction("qbo.account.merged.v1", "QuickBookEvent", false, "AccountMerged"),
+                new HttpRemoteFunction("qbo.account.created.v1", "QuickBookEvent", false, null)
+        );
+        HttpServiceType serviceType = new HttpServiceType("AccountService", fns);
+        String source = new ServiceTypesGenerator(List.of(serviceType)).generate();
+
+        Assert.assertTrue(source.contains("onAccountMerged"),
+                "A display label should be used to build the function name instead of the raw event type");
+        Assert.assertFalse(source.contains("onQboAccountMergedV1"),
+                "The raw event type should not leak into the function name when a display label is set");
+        Assert.assertTrue(source.contains("onQboAccountCreatedV1"),
+                "With no display label, the function name should still be derived from the raw event type");
+    }
+
+    @Test
     void testGenerateWithEmptyRemoteFunctionsThrows() {
         HttpServiceType empty = new HttpServiceType("EmptyService", List.of());
         try {

--- a/asyncapi-tool/README.md
+++ b/asyncapi-tool/README.md
@@ -133,6 +133,8 @@ There are custom tags in this YAML starting with `x-ballerina`. It is very impor
 
 2\. `x-ballerina-event-type` - This should be there in every event inside the channel. This is the name of the event or the value of the attribute mentioned above for a specific event.
 
+3\. `x-ballerina-event-label` (optional) - By default, the generated remote function's name and doc comment are derived directly from `x-ballerina-event-type`. This works well when that value is itself a clean, readable string (e.g. `company.propertyChange`), but some real event sources use type strings with a required prefix/suffix that only makes sense for matching (e.g. a CloudEvents-style `qbo.account.merged.v1`), which produces an awkward function name if used for naming too (`onQboAccountMergedV1`). Set `x-ballerina-event-label` on a message to control the generated name independently (e.g. `AccountMerged` produces `onAccountMerged`), without changing the value actually compared against incoming payloads.
+
 ## Examples
 
 ### Generate HTTP listener from AsyncAPI contract


### PR DESCRIPTION
## Purpose
`x-ballerina-event-type` currently does two jobs at once: it's the exact string compared against incoming payloads, and it's also the raw material the generator splits and title-cases into the generated function name and doc comment. That works fine when both jobs want the same string (e.g. hubspot's `company.propertyChange`), but breaks down for real-world type strings with required prefixes/suffixes that have nothing to do with naming, e.g. CloudEvents-style `qbo.account.merged.v1`, which produces `onQboAccountMergedV1`. Surfaced while migrating the quickbooks trigger to CloudEvents (ballerina-platform/ballerina-library#9079).

## Goals
Let a message optionally control the generated function name and doc comment independently of the value used for wire matching, with zero behavior change for every existing spec that doesn't opt in.

## Approach
Added an optional `x-ballerina-event-label` message extension. When present, it's used as the naming basis instead of `x-ballerina-event-type`; when absent, behavior is byte-for-byte identical to today.

The naming derivation turned out to happen independently in three separate places, all of which had to be updated consistently or the build would fail:
- `GenerateServiceTypeNode` - builds the service type interface's method declaration.
- `GenerateMatchStatementNode` - builds the literal function name string passed to the reflective dispatch call (`executeRemoteFunc`), which must match the interface method exactly.
- `DispatchTestCaseExtractor` - independently derives the same function name again for the generated test file's implementing stub, via a completely separate extraction pass from `ServiceTypeExtractor`.

The match clause literal itself (the actual string compared against incoming payloads) is untouched in all cases - only the naming-facing call sites read the new field, via `HttpRemoteFunction`'s new nullable `displayLabel` field, threaded through from `ServiceTypeExtractor`.

Verified end to end against a real downstream case: the quickbooks trigger's CloudEvents migration (108 messages, 31 entities), where every message now sets `x-ballerina-event-label`, producing `onAccountMerged` instead of `onQboAccountMergedV1` while dispatch still matches correctly against the real wire value.

## User stories
As a trigger spec author integrating a webhook provider whose event type strings carry required wire-format noise (version suffixes, source prefixes), I want the generated Ballerina API to read cleanly, without having to choose between a correct match value and a readable function name.

## Release note
Added an optional `x-ballerina-event-label` message extension to control generated function names and doc comments independently from the `x-ballerina-event-type` value used for wire matching. Fully backward compatible - existing specs are unaffected.

## Documentation
N/A for this PR. A short addition to `asyncapi-tool/README.md`'s DSL tag reference is a natural follow-up but is intentionally left out of this PR's scope.

## Training
N/A - internal generator DSL extension, no training content impact.

## Certification
N/A - internal codegen behavior, not user-facing product surface covered by certification exams.

## Marketing
N/A - internal generator DSL extension.

## Automation tests
- Unit tests
  > Two new tests: `ServiceTypesGeneratorTest.testDisplayLabelOverridesGeneratedFunctionName` (label overrides naming when set) and `DispatcherGeneratorTest.testDisplayLabelDoesNotLeakIntoMatchClauseLiteral` (confirms the match clause still uses the raw wire value even when a label is set). Full existing suite (360/360) passes unchanged, confirming no regression to any spec that doesn't use the new field.
- Integration tests
  > Verified against a real downstream consumer: the quickbooks trigger's CloudEvents migration, regenerated with labels on all 108 messages. `bal build` and `bal test` (108/108) both pass, confirming correct dispatch matching and clean generated names together in a real generated package, not just unit-level assertions.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
The quickbooks trigger's regenerated `service_types.bal`/`dispatcher_service.bal` (companion PR, branch `fix/quickbooks-cloudevents-migration` on `asyncapi-triggers`) is the real-world sample demonstrating the feature end to end.

## Related PRs
- Companion spec migration: `Wicky2002/asyncapi-triggers` branch `fix/quickbooks-cloudevents-migration` (not yet opened as an upstream PR).
- Tracking issue: ballerina-platform/ballerina-library#9079.
- Unrelated but still pending on `architecture-refactor`: #197 (batched-dispatch), #198 (general signing) - this PR does not depend on either.

## Migrations (if applicable)
N/A - purely additive and backward compatible; no existing spec needs any change to keep working exactly as before.

## Test environment
Windows 11, JDK 21, Gradle 8.11.1, Ballerina 2201.13.4 (downstream verification against the quickbooks trigger).


