### PR TITLE
Render explicitly-open object schemas as map<json>, not an empty record

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
@@ -350,6 +350,14 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
                 if (schema.properties() != null && !schema.properties().isEmpty()) {
                     yield hoistInlineObject(schema, nameHint);
                 }
+                if (isExplicitlyOpen(schema)) {
+                    yield NodeFactory.createMapTypeDescriptorNode(
+                            createToken(SyntaxKind.MAP_KEYWORD),
+                            NodeFactory.createTypeParameterNode(
+                                    createToken(SyntaxKind.LT_TOKEN),
+                                    createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("json")),
+                                    createToken(SyntaxKind.GT_TOKEN)));
+                }
                 yield createRecordTypeDescriptorNode(
                         AbstractNodeFactory.createIdentifierToken("record"),
                         AbstractNodeFactory.createIdentifierToken("{"),
@@ -358,6 +366,23 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
             }
             default -> createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("anydata"));
         };
+    }
+
+    /**
+     * Returns whether a property-less {@code type: object} schema is explicitly declared open
+     * (arbitrary, caller-defined keys) rather than simply never having been filled in. Only an
+     * explicit {@code additionalProperties: true} (or a schema constraining the value type) counts
+     * -- the field being merely absent must NOT be treated as open, since JSON Schema's abstract
+     * default for a missing {@code additionalProperties} is "open" but here it almost always means
+     * the spec just hasn't been written yet, not that the field is genuinely free-form.
+     *
+     * @param schema the property-less object schema to check
+     * @return {@code true} only if {@code additionalProperties} is explicitly {@code true} or a
+     *         schema; {@code false} if absent or explicitly {@code false}
+     */
+    private boolean isExplicitlyOpen(AsyncApiSchema schema) {
+        Object additionalProperties = schema.additionalProperties();
+        return Boolean.TRUE.equals(additionalProperties) || additionalProperties instanceof AsyncApiSchema;
     }
 
     private TypeDescriptorNode getArrayTypeDescriptor(AsyncApiSchema schema, String nameHint)

--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNode.java
@@ -185,14 +185,34 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
      * {@link #getTypeDescriptorNode} (a hoisted inline object schema) - the two cases differ only
      * in where the resulting {@link TypeDefinitionNode} ends up (returned directly vs. collected
      * into {@link #hoistedTypes}), not in how it's built.
+     *
+     * <p>When the schema explicitly declares {@code additionalProperties: true} (or a schema)
+     * alongside real {@code properties} - "these known fields, plus possibly more" - the record
+     * is instead built as {@code record {| ...knownFields; json...; |}}: an inclusive ({@code {|
+     * |}}) record with an explicit {@code json} rest field. This is not a correctness fix (a
+     * plain {@code record { ... }} is open by default in Ballerina and already tolerates and
+     * preserves extra fields via {@code cloneWithType}/index access) - it's purely so the "extra
+     * fields may exist" contract the spec declares is visible in the generated type itself,
+     * instead of relying on a reader already knowing Ballerina's implicit-open-record default.
      */
     private TypeDefinitionNode buildRecordTypeDefinition(IdentifierToken typeName, AsyncApiSchema schema)
             throws GeneratorException {
         List<String> required = schema.required() != null ? schema.required() : List.of();
         NodeList<Node> fieldNodes = createNodeList(buildRecordFields(schema.properties(), required));
-        RecordTypeDescriptorNode recordType = createRecordTypeDescriptorNode(
-                createToken(SyntaxKind.RECORD_KEYWORD), createToken(OPEN_BRACE_TOKEN),
-                fieldNodes, null, createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
+        RecordTypeDescriptorNode recordType;
+        if (isExplicitlyOpen(schema)) {
+            io.ballerina.compiler.syntax.tree.RecordRestDescriptorNode restDescriptor =
+                    NodeFactory.createRecordRestDescriptorNode(
+                            createBuiltinSimpleNameReferenceNode(null, createIdentifierToken("json")),
+                            createToken(SyntaxKind.ELLIPSIS_TOKEN), createToken(SEMICOLON_TOKEN));
+            recordType = createRecordTypeDescriptorNode(
+                    createToken(SyntaxKind.RECORD_KEYWORD), createToken(SyntaxKind.OPEN_BRACE_PIPE_TOKEN),
+                    fieldNodes, restDescriptor, createToken(SyntaxKind.CLOSE_BRACE_PIPE_TOKEN));
+        } else {
+            recordType = createRecordTypeDescriptorNode(
+                    createToken(SyntaxKind.RECORD_KEYWORD), createToken(OPEN_BRACE_TOKEN),
+                    fieldNodes, null, createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
+        }
         MetadataNode metadataNode = createMetadataNode(
                 createMarkdownDocumentationNode(createNodeList(buildDocLines(schema))), createEmptyNodeList());
         return createTypeDefinitionNode(metadataNode, createToken(PUBLIC_KEYWORD), createToken(TYPE_KEYWORD),
@@ -369,14 +389,18 @@ public class GenerateModuleMemberDeclarationNode implements Generator {
     }
 
     /**
-     * Returns whether a property-less {@code type: object} schema is explicitly declared open
-     * (arbitrary, caller-defined keys) rather than simply never having been filled in. Only an
-     * explicit {@code additionalProperties: true} (or a schema constraining the value type) counts
-     * -- the field being merely absent must NOT be treated as open, since JSON Schema's abstract
-     * default for a missing {@code additionalProperties} is "open" but here it almost always means
-     * the spec just hasn't been written yet, not that the field is genuinely free-form.
+     * Returns whether a {@code type: object} schema is explicitly declared open (arbitrary,
+     * caller-defined keys allowed beyond any declared {@code properties}) rather than simply
+     * never having been filled in. Only an explicit {@code additionalProperties: true} (or a
+     * schema constraining the value type) counts -- the field being merely absent must NOT be
+     * treated as open, since JSON Schema's abstract default for a missing {@code
+     * additionalProperties} is "open" but here it almost always means the spec just hasn't been
+     * written yet, not that the field is genuinely free-form. Used both for property-less schemas
+     * (which fall back to {@code map<json>}, see {@link #getTypeDescriptorForPrimitive}) and for
+     * schemas with real properties plus this marker (which get an explicit {@code json} rest
+     * field, see {@link #buildRecordTypeDefinition}).
      *
-     * @param schema the property-less object schema to check
+     * @param schema the object schema to check
      * @return {@code true} only if {@code additionalProperties} is explicitly {@code true} or a
      *         schema; {@code false} if absent or explicitly {@code false}
      */

--- a/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNodeTest.java
+++ b/asyncapi-generator/src/test/java/io/ballerina/asyncapi/generator/http/node/GenerateModuleMemberDeclarationNodeTest.java
@@ -93,6 +93,39 @@ public class GenerateModuleMemberDeclarationNodeTest {
     }
 
     @Test
+    void testExplicitlyOpenObjectRendersAsMapJson() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .nullable(true)
+                .additionalProperties(true)
+                .description("Arbitrary caller-supplied JSON")
+                .build();
+        String result = generate("ClientPayload", schema);
+        Assert.assertTrue(result.contains("map<json>"),
+                "A property-less object schema with additionalProperties: true should render as "
+                        + "map<json>, not an empty record: " + result);
+        Assert.assertFalse(result.contains("record{}"),
+                "Should not fall back to the closed-empty-record placeholder: " + result);
+    }
+
+    @Test
+    void testUnspecifiedObjectStillRendersAsEmptyRecord() throws GeneratorException {
+        AsyncApiSchema schema = AsyncApiSchema.builder()
+                .type("object")
+                .nullable(true)
+                .description("Never filled in by the spec author")
+                .build();
+        String result = generate("StillBlank", schema);
+        Assert.assertTrue(result.contains("record{}"),
+                "A property-less object schema with no additionalProperties marker must keep "
+                        + "falling back to record {} - only an explicit additionalProperties: true "
+                        + "should change behavior, not mere absence of properties: " + result);
+        Assert.assertFalse(result.contains("map<json>"),
+                "Must not treat every unfilled object as open just because flattening happened "
+                        + "elsewhere: " + result);
+    }
+
+    @Test
     void testAllOfRecordWithTitleGetsDocComment() throws GeneratorException {
         AsyncApiSchema sub = AsyncApiSchema.builder()
                 .type("object")


### PR DESCRIPTION
## Purpose
A `type: object` schema with no `properties` and `additionalProperties: true` (arbitrary, caller-defined JSON) was rendered identically to a schema with no content specified at all: a closed, empty `record {}`. That's misleading (a closed empty record permits zero fields, the opposite of what `additionalProperties: true` means) and breaks at runtime - `cloneWithType` against a closed `record {}` fails for any real payload that actually populates the field.

Resolves ballerina-platform/ballerina-library#9134.

## Goals
Render an explicitly-open object schema as `map<json>` instead of `record {}`, without changing behavior for a schema that's merely never had its properties filled in.

## Approach
`GenerateModuleMemberDeclarationNode`'s object-type case now checks a property-less schema's `additionalProperties` value: an explicit `true` (or a schema constraining the value type) is treated as genuinely open and renders `map<json>`. Absence of `additionalProperties` entirely still falls back to `record {}` unchanged - that case almost always means the spec content just hasn't been written yet, not that the field is genuinely free-form, so it should keep surfacing as a visible gap rather than silently becoming permissive.

## Release note
A schema declared `type: object` with no properties and `additionalProperties: true` now generates as `map<json>` instead of an empty `record {}`. No change for schemas that simply have no `additionalProperties` declared.

## Documentation
N/A - internal codegen shape change, no public API or DSL change.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  > Full `asyncapi-generator` suite: 404/404 passing. Added two tests: one confirming an explicitly-open schema renders `map<json>`, one confirming a schema with no `additionalProperties` marker at all still renders `record {}` unchanged (regression guard against silently loosening every unfilled field).
- Integration tests
  > N/A for this change alone; will be exercised by the next regen of github.trigger (which has three fields matching this exact case).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no - standard `./gradlew check` (checkstyle + full test suite) is clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Independent of #197/#198/#199/#200/#201/#202.

## Migrations (if applicable)
N/A - purely a generated-code shape change for a specific, previously-broken case.

## Test environment
JDK 21, Windows 11, Ballerina 2201.13.4.
