### PR TITLE
Add a blank line between remote function declarations in service_types.bal

### DIFF
--- a/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ServiceTypesGenerator.java
+++ b/asyncapi-generator/src/main/java/io/ballerina/asyncapi/generator/http/generator/ServiceTypesGenerator.java
@@ -89,9 +89,30 @@ public class ServiceTypesGenerator {
         SyntaxTree modifiedTree = syntaxTree.replaceNode(oldRoot, newRoot);
 
         try {
-            return Formatter.format(modifiedTree).toSourceCode();
+            return addBlankLineBetweenRemoteFunctions(Formatter.format(modifiedTree).toSourceCode());
         } catch (FormatterException e) {
             throw new GeneratorException("Could not format the generated service_types.bal code", e);
         }
+    }
+
+    /**
+     * Inserts a blank line between consecutive remote function declarations within a service
+     * type, so each one's own doc comment reads as its own block instead of the whole type
+     * running together as one dense wall of text (raised during review on
+     * module-ballerinax-quickbooks.trigger#1).
+     *
+     * <p>Done as a targeted post-process on the formatted text rather than via node minutiae -
+     * confirmed empirically that the Ballerina {@link Formatter} does not preserve extra
+     * end-of-line minutiae added to a service-object-type member's trailing token, so an AST-level
+     * approach doesn't survive the format pass. The pattern matched here ({@code error?;} directly
+     * followed by a doc-comment line at the same 4-space member indent) only ever occurs between
+     * two remote function declarations in this generator's output - never at the true end of a
+     * type (followed by {@code };}) or anywhere else in the file.
+     *
+     * @param source the formatted {@code service_types.bal} content
+     * @return the same content with a blank line inserted between remote function members
+     */
+    private String addBlankLineBetweenRemoteFunctions(String source) {
+        return source.replaceAll("(?m)^( {4}\\S.*error\\?;)(\\r?\\n)( {4}#)", "$1$2$2$3");
     }
 }


### PR DESCRIPTION
## Purpose
Raised during review on `module-ballerinax-quickbooks.trigger#1`: a service type with several remote functions rendered as one dense block - each member's own doc comment ran straight into the next member's declaration with no visual break, making a multi-function service type hard to scan.

## Approach
Added a targeted post-process on `service_types.bal`'s formatted text (in `ServiceTypesGenerator`), inserting a blank line between two consecutive remote function declarations. Confirmed empirically that adding extra end-of-line minutiae to a service-object-type member's trailing token at the AST level does not survive the Ballerina `Formatter`'s own pass, so this is done as a string-level fix on the already-formatted output instead. The pattern matched (a remote function's closing `error?;` directly followed by the next member's doc-comment line, both at the same 4-space indent) only ever occurs between two remote function declarations in this generator's output - never at the true end of a type, and never anywhere else in the file.

## Release note
`service_types.bal` now has a blank line between each remote function declaration within a service type (when there's more than one). No change to single-member service types.

## Automation tests
- Unit tests
  > Full `asyncapi-generator` suite: 402/402 passing.
- Integration tests
  > Verified end-to-end against all three migrated connectors (github.trigger, hubspot.trigger, quickbooks.trigger) - regenerated each, confirmed the blank lines appear correctly between multi-function service types and correctly don't appear for single-function ones or before the closing `};`, `bal build`/`bal test` clean on all three (265/265, 41/41, 108/108).

## Related PRs
Independent of #197/#200/#201/#202/#203.