### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/asyncapi-cli/build.gradle
+++ b/asyncapi-cli/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "java-library"
     id "checkstyle"
 }

--- a/asyncapi-tool/build.gradle
+++ b/asyncapi-tool/build.gradle
@@ -18,6 +18,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -64,8 +71,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml BalTool.toml"

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,13 @@ plugins {
     id 'maven-publish'
     id "com.github.spotbugs"
     id "jacoco"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "de.undercouch.download"
     id "net.researchgate.release"
+}
+
+jacoco {
+    toolVersion = jacocoVersion
 }
 
 def packageName = "asyncapi"
@@ -123,9 +127,9 @@ task codeCoverageReport(type: JacocoReport) {
         xml.required = true
         html.required = true
         csv.required = true
-        xml.destination(new File("${buildDir}/reports/jacoco/report.xml"))
-        html.destination(new File("${buildDir}/reports/jacoco/report.html"))
-        csv.destination(new File("${buildDir}/reports/jacoco/report.csv"))
+        xml.outputLocation.set(new File("${buildDir}/reports/jacoco/report.xml"))
+        html.outputLocation.set(new File("${buildDir}/reports/jacoco/report.html"))
+        csv.outputLocation.set(new File("${buildDir}/reports/jacoco/report.csv"))
     }
 
     onlyIf = {
@@ -188,7 +192,7 @@ task directoryBuild {
 }
 
 task createArtifactZip(type: Zip) {
-    destinationDirectory = file("${buildDir}/distributions")
+    destinationDirectory = layout.buildDirectory.dir("distributions").get().asFile
     from directoryBuild
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ directoryBuild.dependsOn ":checkstyle:checkstyleTest"
 directoryBuild.dependsOn ":checkstyle:test"
 directoryBuild.dependsOn ":checkstyle:processTestResources"
 
+directoryBuild.dependsOn ":shadowJar"
 directoryBuild.dependsOn ":asyncapi-tool:jBallerinaPack"
 directoryBuild.dependsOn ":asyncapi-tool:generatePomFileForMavenPublication"
 directoryBuild.dependsOn ":asyncapi-tool:createArtifactZip"

--- a/config/checkstyle/build.gradle
+++ b/config/checkstyle/build.gradle
@@ -27,7 +27,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -38,10 +38,12 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,18 @@ version=0.12.1-SNAPSHOT
 artifactId=asyncapi-tool
 
 # Plugin Versions
-spotbugsPluginVersion=6.0.18
-shadowJarPluginVersion=8.1.1
+spotbugsPluginVersion=6.5.1
+shadowJarPluginVersion=9.6.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 checkstylePluginVersion=10.12.1
 javaModularityPluginVersion=1.7.0
 sonarqubePluginVersion=4.0.0.2929
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 
 #dependency
 ballerinaLangVersion=2201.13.4
+jacocoVersion=0.8.14
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 commonsIoVersion=2.11.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,7 @@
 pluginManagement {
     plugins {
         id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
-        id 'com.github.johnrengelman.shadow' version "${shadowJarPluginVersion}"
+        id 'com.gradleup.shadow' version "${shadowJarPluginVersion}"
         id 'de.undercouch.download' version "${downloadPluginVersion}"
         id 'net.researchgate.release' version "${releasePluginVersion}"
         id 'org.sonarqube' version "${sonarqubePluginVersion}"
@@ -39,7 +39,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'asyncapi-tools'
@@ -50,9 +50,9 @@ include(':native.handler:java-wrapper')
 include(':asyncapi-cli')
 include(':asyncapi-tool')
 project(':checkstyle').projectDir = file("config${File.separator}checkstyle")
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, checkstyle's `build.gradle` drops the deprecated `buildDir` property, and `:checkstyle:test` no longer races with `:checkstyle:downloadCheckstyleRuleFiles`.
- Migrate the abandoned `com.github.johnrengelman.shadow` plugin to the maintained `com.gradleup.shadow` fork — the old plugin's `ShadowCopyAction` references a Gradle-internal property Gradle 9.5.1 no longer exposes, breaking `shadowJar` with "No such property: mode".
- Declare `:directoryBuild`'s dependency on `:shadowJar` explicitly (Gradle 9's stricter task-validation flagged the missing declaration).

## Test plan
- [x] `./gradlew clean build -x test` passes locally on Gradle 9.5.1 with plugin 4.0.0, verified with a from-scratch clean build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Upgraded the Gradle wrapper to 9.5.1 with checksum verification.
- Upgraded the Ballerina Gradle plugin and related build plugins for Java 21/25 compatibility.
- Replaced deprecated Gradle APIs with `ExecOperations` and `layout.buildDirectory`.
- Migrated from Gradle Enterprise to Gradle Develocity.
- Replaced the abandoned Shadow plugin with `com.gradleup.shadow`.
- Added task ordering and dependency declarations to prevent task races and satisfy Gradle 9 validation.
- Updated JaCoCo configuration and plugin versions.
- Verified a clean build with tests excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->