### PR TITLE
[DO NOT MERGE] Test Java 21/25 compatibility via ballerina-library dev workflows

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -15,5 +15,5 @@ jobs:
   call_workflow:
     name: Run Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@dev
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@dev
     secrets: inherit

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -9,5 +9,5 @@ jobs:
   call_workflow:
     name: Run Trivy Scan Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@dev
     secrets: inherit

--- a/asyncapi-cli/build.gradle
+++ b/asyncapi-cli/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "java-library"
     id "checkstyle"
 }

--- a/asyncapi-tool/build.gradle
+++ b/asyncapi-tool/build.gradle
@@ -18,6 +18,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -64,8 +71,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml BalTool.toml"

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,13 @@ plugins {
     id 'maven-publish'
     id "com.github.spotbugs"
     id "jacoco"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "de.undercouch.download"
     id "net.researchgate.release"
+}
+
+jacoco {
+    toolVersion = jacocoVersion
 }
 
 def packageName = "asyncapi"
@@ -123,9 +127,9 @@ task codeCoverageReport(type: JacocoReport) {
         xml.required = true
         html.required = true
         csv.required = true
-        xml.destination(new File("${buildDir}/reports/jacoco/report.xml"))
-        html.destination(new File("${buildDir}/reports/jacoco/report.html"))
-        csv.destination(new File("${buildDir}/reports/jacoco/report.csv"))
+        xml.outputLocation.set(new File("${buildDir}/reports/jacoco/report.xml"))
+        html.outputLocation.set(new File("${buildDir}/reports/jacoco/report.html"))
+        csv.outputLocation.set(new File("${buildDir}/reports/jacoco/report.csv"))
     }
 
     onlyIf = {
@@ -188,7 +192,7 @@ task directoryBuild {
 }
 
 task createArtifactZip(type: Zip) {
-    destinationDirectory = file("${buildDir}/distributions")
+    destinationDirectory = layout.buildDirectory.dir("distributions").get().asFile
     from directoryBuild
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ directoryBuild.dependsOn ":checkstyle:checkstyleTest"
 directoryBuild.dependsOn ":checkstyle:test"
 directoryBuild.dependsOn ":checkstyle:processTestResources"
 
+directoryBuild.dependsOn ":shadowJar"
 directoryBuild.dependsOn ":asyncapi-tool:jBallerinaPack"
 directoryBuild.dependsOn ":asyncapi-tool:generatePomFileForMavenPublication"
 directoryBuild.dependsOn ":asyncapi-tool:createArtifactZip"

--- a/config/checkstyle/build.gradle
+++ b/config/checkstyle/build.gradle
@@ -27,7 +27,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -38,10 +38,12 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,18 @@ version=0.12.1-SNAPSHOT
 artifactId=asyncapi-tool
 
 # Plugin Versions
-spotbugsPluginVersion=6.0.18
-shadowJarPluginVersion=8.1.1
+spotbugsPluginVersion=6.5.1
+shadowJarPluginVersion=9.6.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 checkstylePluginVersion=10.12.1
 javaModularityPluginVersion=1.7.0
 sonarqubePluginVersion=4.0.0.2929
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 
 #dependency
 ballerinaLangVersion=2201.13.4
+jacocoVersion=0.8.14
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 commonsIoVersion=2.11.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,7 @@
 pluginManagement {
     plugins {
         id 'com.github.spotbugs' version "${spotbugsPluginVersion}"
-        id 'com.github.johnrengelman.shadow' version "${shadowJarPluginVersion}"
+        id 'com.gradleup.shadow' version "${shadowJarPluginVersion}"
         id 'de.undercouch.download' version "${downloadPluginVersion}"
         id 'net.researchgate.release' version "${releasePluginVersion}"
         id 'org.sonarqube' version "${sonarqubePluginVersion}"
@@ -39,7 +39,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'asyncapi-tools'
@@ -50,9 +50,9 @@ include(':native.handler:java-wrapper')
 include(':asyncapi-cli')
 include(':asyncapi-tool')
 project(':checkstyle').projectDir = file("config${File.separator}checkstyle")
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
**DO NOT MERGE — this PR exists only to run CI against the `ballerina-library` `dev` branch workflows for Java 21/25 compatibility testing.**

Combines the gradle upgrade from PR 1 with pointing this repo's `ballerina-library` reusable workflows at `dev` instead of `main`. Close (don't merge) once the `dev` branch changes land upstream in `ballerina-library`'s `main` — PR 1 is the one that should land here.

## Test plan
- [ ] CI passes on the `dev` ballerina-library workflows for Java 21 and Java 25
